### PR TITLE
added other message dependencies

### DIFF
--- a/crazyswarm2_interfaces/CMakeLists.txt
+++ b/crazyswarm2_interfaces/CMakeLists.txt
@@ -12,6 +12,9 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -31,7 +34,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/Takeoff.srv"
   "srv/UpdateParams.srv"
   "srv/UploadTrajectory.srv"
-  DEPENDENCIES builtin_interfaces
+  DEPENDENCIES builtin_interfaces geometry_msgs std_msgs 
   ADD_LINTER_TESTS
 )
 


### PR DESCRIPTION
The message generation were still missing dependencies of geometry_msgs  std_msgs. With these changes, crazyswarm2_interfaces should build properly.