### PR TITLE
Teleop: Support for takeoff/landing, even when using low-level flight mode

### DIFF
--- a/crazyswarm2/config/teleop.yaml
+++ b/crazyswarm2/config/teleop.yaml
@@ -1,6 +1,6 @@
 /teleop:
   ros__parameters:
-    frequency: 100 
+    frequency: 100  # set to 0, to disable manual flight modes
     mode: "cmd_vel_world" # one of cmd_rpy, cmd_vel_world
     cmd_rpy:
       x_velocity_axis: 5

--- a/crazyswarm2/launch/launch.py
+++ b/crazyswarm2/launch/launch.py
@@ -79,14 +79,15 @@ def generate_launch_description():
                 ('takeoff', 'cf231/takeoff'),
                 ('land', 'cf231/land'),
                 ('cmd_vel', 'cf231/cmd_vel'),
-                ('cmd_full_state', 'cf231/cmd_full_state')
+                ('cmd_full_state', 'cf231/cmd_full_state'),
+                ('notify_setpoints_stop', 'cf231/notify_setpoints_stop'),
             ],
             parameters=[teleop_yaml]
         ),
         Node(
             package='joy',
             executable='joy_node',
-            name='joy_node' # by default id=0, new joystick
+            name='joy_node' # by default id=0
         ),
         Node(
             package='crazyswarm2',

--- a/crazyswarm2/launch/launch_teleop2.py
+++ b/crazyswarm2/launch/launch_teleop2.py
@@ -84,6 +84,7 @@ def generate_launch_description():
                 ('land', 'cf231/land'),
                 ('cmd_vel', 'cf231/cmd_vel'),
                 ('cmd_full_state', 'cf231/cmd_full_state'),
+                ('notify_setpoints_stop', 'cf231/notify_setpoints_stop'),
                 ('joy', 'cf231/joy'),
             ],
             parameters=[teleop_yaml]
@@ -97,6 +98,7 @@ def generate_launch_description():
                 ('land', 'cf5/land'),
                 ('cmd_vel', 'cf5/cmd_vel'),
                 ('cmd_full_state', 'cf5/cmd_full_state'),
+                ('notify_setpoints_stop', 'cf5/notify_setpoints_stop'),
                 ('joy', 'cf5/joy'),
             ],
             parameters=[teleop_5_yaml]


### PR DESCRIPTION
* Add a new variable track if low-level (joystick) flight is active
  (true after takeoff, false after landing)
* Use NotifySetpointsStop to properly switch from low -> high-level mode
  for landing