### PR TITLE
improve error reporting for parameters of the wrong type

### DIFF
--- a/crazyswarm2/src/crazyswarm2_server.cpp
+++ b/crazyswarm2/src/crazyswarm2_server.cpp
@@ -191,7 +191,10 @@ public:
       // Update parameters
       for (const auto&i : set_param_map) {
         std::string paramName = name + "/params/" + std::regex_replace(i.first, std::regex("\\."), "/");
-        node->set_parameter(rclcpp::Parameter(paramName, i.second));
+        auto result = node->set_parameter(rclcpp::Parameter(paramName, i.second));
+        if (!result.successful) {
+            RCLCPP_ERROR(logger_, "Could not set param %s (%s)", i.first.c_str(), result.reason.c_str());
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #40.

The error message will be now:

```
[cf2]: Could not set param ctrlMel.kp_xy (Wrong parameter type, parameter {cf2/params/ctrlMel/kp_xy} is of type {double}, setting it to {integer} is not allowed.)
```