### PR TITLE
py server param handling

### DIFF
--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -69,6 +69,13 @@ class CrazyflieServer(Node):
     def _connected(self, link_uri):
         self.get_logger().info(f" {link_uri} is connected!")
 
+        # Get the TOC of parameters
+        p_toc = self.swarm._cfs[link_uri].cf.param.toc.toc
+        for group in sorted(p_toc.keys()):
+            print('{}'.format(group))
+            for param in sorted(p_toc[group].keys()):
+                print('\t{}'.format(param))
+
     def _disconnected(self, link_uri):
         self.get_logger().info(f" {link_uri} is disconnected!")
 

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -54,7 +54,6 @@ class CrazyflieServer(Node):
         self.swarm.all_fully_connected = False
         for link_uri in self.uris:
             self.swarm._cfs[link_uri].cf.fully_connected.add_callback(self._fully_connected)
-            self.swarm._cfs[link_uri].cf.connected.add_callback(self._connected)
             self.swarm._cfs[link_uri].cf.disconnected.add_callback(self._disconnected)
             self.swarm._cfs[link_uri].cf.connection_failed.add_callback(
                 self._connection_failed
@@ -120,8 +119,6 @@ class CrazyflieServer(Node):
                         for link_uri_temp in self.uris:
                             self.swarm._cfs[link_uri_temp].cf.param.set_value(name, parameter.value)
 
-    def _connected(self, link_uri):
-        self.get_logger().info(f" {link_uri} is connected!")
 
     def _disconnected(self, link_uri):
         self.get_logger().info(f" {link_uri} is disconnected!")

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -8,8 +8,7 @@ from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.swarm import CachedCfFactory
 from cflib.crazyflie.swarm import Swarm
 
-from crazyflie_interfaces.srv import Takeoff, Land, GoTo
-from rcl_interfaces.msg import ParameterDescriptor
+from crazyswarm2_interfaces.srv import Takeoff, Land, GoTo
 
 from geometry_msgs.msg import Twist
 

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -88,7 +88,7 @@ class CrazyflieServer(Node):
         self.swarm.fully_connected_crazyflie_cnt += 1
 
         if self.swarm.fully_connected_crazyflie_cnt == len(self.cf_dict):
-            self.get_logger().info("All Crazyflies are is fully connected!")
+            self.get_logger().info("All Crazyflies are fully connected!")
             self.swarm.all_fully_connected = True
             self._sync_parameters()
             self.add_on_set_parameters_callback(self.parameters_callback)

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -85,13 +85,17 @@ class CrazyflieServer(Node):
         self.swarm._cfs[link_uri].total_param_cnt = param_cnt
 
     def _param_callback(self, name, value, link_uri='all'):
-        self.declare_parameter(self.cf_dict[link_uri]+'/'+name.replace(".","/"), value)
+        self.declare_parameter(self.cf_dict[link_uri]+'/params/'+name.replace(".","/"), value)
+        try:
+            self.declare_parameter('firmware_params/'+name.replace(".","/"), value)
+        except:
+            self.get_logger().info(f" {name} is already declared!")
+
         self.swarm._cfs[link_uri].init_param_cnt += 1
         group = name.split()[0]
         self.swarm._cfs[link_uri].cf.param.remove_update_callback(group=group, name=name, cb=self._param_callback)
         if self.swarm._cfs[link_uri].init_param_cnt == self.swarm._cfs[link_uri].total_param_cnt:
             self.get_logger().info(f" {link_uri} is fully connected!")
-
 
     def _disconnected(self, link_uri):
         self.get_logger().info(f" {link_uri} is disconnected!")

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -109,14 +109,14 @@ class CrazyflieServer(Node):
                     final_value = None
 
                     # First check and set global parameters
-                    global_init_param_name = "firmware_params." + name
+                    global_init_param_name = "all_robots.firmware_params." + name
                     global_parameter = self.get_parameter_or(global_init_param_name)
                     if global_parameter.value is not None:
                         final_value = global_parameter.value
 
                     # Then check and set Type parameters
                     type_init_param_name = (
-                        "crazyflie_types."
+                        "robot_types."
                         + self.type_dict[link_uri]
                         + ".firmware_params."
                         + name
@@ -127,7 +127,7 @@ class CrazyflieServer(Node):
 
                     # Then check and set individual paramters
                     cf_init_param_name = (
-                        "crazyflies."
+                        "robots."
                         + self.cf_dict[link_uri]
                         + ".firmware_params."
                         + name

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -49,6 +49,7 @@ class CrazyflieServer(Node):
         self.swarm = Swarm(self.uris, factory=factory)
         self.swarm.all_fully_connected = False
         for link_uri in self.uris:
+            self.swarm._cfs[link_uri].cf.fully_connected.add_callback(self._fully_connected)
             self.swarm._cfs[link_uri].cf.connected.add_callback(self._connected)
             self.swarm._cfs[link_uri].cf.disconnected.add_callback(self._disconnected)
             self.swarm._cfs[link_uri].cf.connection_failed.add_callback(
@@ -80,6 +81,8 @@ class CrazyflieServer(Node):
                 Twist, name + "/cmd_vel", partial(self._cmd_vel_changed, uri=uri), 10
             )
 
+    def _fully_connected(self, link_uri):
+        self.get_logger().info(f" {link_uri} is fully connected!")
 
 
     def _connected(self, link_uri):

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -8,7 +8,8 @@ from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.swarm import CachedCfFactory
 from cflib.crazyflie.swarm import Swarm
 
-from crazyswarm2_interfaces.srv import Takeoff, Land, GoTo
+from crazyflie_interfaces.srv import Takeoff, Land, GoTo
+from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult
 
 from geometry_msgs.msg import Twist
 

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -30,23 +30,18 @@ class CrazyflieServer(Node):
         )
         with open(crazyflies_yaml) as f:
             data = yaml.safe_load(f)
+
         self.uris = []
-<<<<<<< HEAD
-        cf_dict = {}
-        for crazyflie in data["robots"]:
-            uri = data["robots"][crazyflie]["uri"]
-=======
         self.cf_dict = {}
         self.uri_dict = {}
         self.type_dict = {}
 
-        for crazyflie in data:
-            uri = data[crazyflie]["uri"]
->>>>>>> reset parameters after fully connected
+        for crazyflie in data["robots"]:
+            uri = data["robots"][crazyflie]["uri"]
             self.uris.append(uri)
             self.cf_dict[uri] = crazyflie
             self.uri_dict[crazyflie] = uri
-            type_cf = data[crazyflie]["type"]
+            type_cf = data["robots"][crazyflie]["type"]
             self.type_dict[uri] = type_cf
 
         # Setup Swarm class cflib with connection callbacks and open the links

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -11,7 +11,6 @@ from cflib.crazyflie.swarm import Swarm
 from crazyflie_interfaces.srv import Takeoff, Land, GoTo
 from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult, ParameterType
 from rclpy.parameter import Parameter
-from rclpy.executors import MultiThreadedExecutor
 
 from geometry_msgs.msg import Twist
 
@@ -43,7 +42,6 @@ class CrazyflieServer(Node):
         self.cf_dict = {}
         self.uri_dict = {}
         self.type_dict = {}
-        self.param_dict = {}
 
         for crazyflie in data:
             uri = data[crazyflie]["uri"]
@@ -94,133 +92,23 @@ class CrazyflieServer(Node):
         self.param_set_event = Event()
         self.param_value_check = None
 
-        self.param_list = {}
-        for name, param in self._parameters.items():
-            name_split = name.split('.')
-            d_name, keys = name_split[0], name_split[1:]
-            d = vars()[d_name]
-            for key in keys:
-                d = d.get(key, None)
-                if d is None:
-                    break
-            print(d)
-
-            print(len(name_split), name)
-            if len(name_split) ==3:
-                self.param_list.update({name_split[0]: {name_split[1]: {name_split[2]: param.value}}})
-            elif len(name_split) ==4:
-                self.param_list.update({name_split[0]: {name_split[1]: {name_split[2]: {name_split[3]: param.value}}}})
-            elif len(name_split) ==5:
-                self.param_list.update({name_split[0]: {name_split[1]: {name_split[2]: {name_split[3]: {name_split[4]: param.value}}}}})
-
     def _fully_connected(self, link_uri):
         self.get_logger().info(f" {link_uri} is fully connected!")
 
         self.swarm.fully_connected_crazyflie_cnt += 1
-        self._set_cf_parameters_from_ROS(self.swarm._cfs[link_uri].cf,self.type_dict[link_uri], self.cf_dict[link_uri])
 
         if self.swarm.fully_connected_crazyflie_cnt == len(self.cf_dict):
             self.get_logger().info("All Crazyflies are is fully connected!")
             self.swarm.all_fully_connected = True
-            #self._sync_parameters()
+            self._sync_parameters()
         else:
             return
 
-    def _set_cf_parameters_from_ROS(self, cf, cf_type, cf_name):
-        cf.param.add_update_callback(group=None, name=None, cb=self._param_callback)
-
-        # First check global parameter list
-        final_value = None
-        print(self.param_list)
-        for group in self.param_list['firmware_params'].items():
-            print(group)
-            for param, val in self.param_list['firmware_params'][group].items():
-                print(param)
-                name = group + '.' + param
-                cf.param.set_value(name, val)
-                print(name,val,'global')
-        
-        # Second check type parameter list
-        if cf_type in self.param_list['crazyflie_types']:
-            if 'firmware_params' in self.param_list['crazyflies'][cf_type]:
-                dict_temp = self.param_list['crazyflie_types'][cf_type]['firmware_params']
-                for group in dict_temp.keys():
-                    for param, val in dict_temp[group].items():
-                        name = group + '.' + param
-                        cf.param.set_value(name, val)
-                        print(name,val,'type')
-
-        # Second check type parameter list
-        if cf_name in  self.param_list['crazyflies']:
-            if 'firmware_params' in self.param_list['crazyflies'][cf_name]:
-                dict_temp = self.param_list['crazyflies'][cf_name]['firmware_params']
-                for group in dict_temp.keys():
-                    for param, val in dict_temp[group].items():
-                        name = group + '.' + param
-                        cf.param.set_value(name, val)
-                        print(name,val,'individual')
-
-    def _set_and_check_parameter(self, cf, name, value, max_tries):
-
-        try_cnt = 0
-        while True:
-            try:
-                self._compare_paramater_value(cf, name, value)
-                break
-            except Exception as e:
-                print(str(e))
-                time.sleep(1)
-                try_cnt += 1
-                if try_cnt>max_tries:
-                    raise Exception('Too many tries for parameters')
-                continue
-
-
-    def _compare_paramater_value(self, cf, name, value):
-        group = name.split('.')[0]
-        param = name.split('.')[1]
-
-        cf.param.set_value(name, value)
-        cf.param.set_value(name, value)
-        cf.param.set_value(name, value)
-
-        time.sleep(1)
-
-        get_value = cf.param.get_value(name)
-
-        if get_value is None:
-            raise Exception('value is none')
-
-        if not isclose(float(get_value), float(value), abs_tol=1e-5):
-            raise Exception(f'value {name} not the same {get_value}, {value}')
-
-
-    def _get_parameter_value(self, cf, name ):
-        cf_param_value = None
-        while True:
-            try: 
-                cf_param_value = cf.param.get_value(name,timeout=1)
-                break
-            except Exception as e:
-                print(str(e))
-                time.sleep(1)
-                continue 
-        return cf_param_value
-
-    def _param_callback(self, name, value):
-        """Generic callback registered for all the groups"""
-        print('{0}: {1}'.format(name, value))
-
-    def _ros_param_callback(self, params):
-        for param in params:
-            print(vars(param))
-        return SetParametersResult(successful=True)
 
     def _sync_parameters(self):
         
         for link_uri in self.uris:
             cf = self.swarm._cfs[link_uri].cf
-            cf.param.add_update_callback(group=None, name=None, cb=self._param_callback)
 
             p_toc = cf.param.toc.toc
 
@@ -247,17 +135,11 @@ class CrazyflieServer(Node):
 
                     if final_value is not None:
                         cf.param.set_value(name, final_value)
-                        time.sleep(3)
-                        cf_param_value = cf.param.get_value(name,timeout=1)
-                        print(name, cf_param_value, final_value)
-
-                        #self._set_and_check_parameter(cf, name, final_value, 3)
 
                     elem = p_toc[group][param]
                     type_cf_param = elem.ctype
-                    
-                
-                    cf_param_value = self._get_parameter_value(cf, name)
+
+                    cf_param_value = cf.param.get_value(name)
 
 
                     if cf_param_value is not None:
@@ -371,10 +253,7 @@ def main(args=None):
     rclpy.init(args=args)
     crazyflie_server = CrazyflieServer()
 
-    executor = MultiThreadedExecutor(num_threads=4)
-    executor.add_node(crazyflie_server)
-
-    executor.spin()
+    rclpy.spin(crazyflie_server)
 
     executor.shutdown()
     crazyflie_server.destroy_node()

--- a/crazyflie_server_py/launch/server_launch.py
+++ b/crazyflie_server_py/launch/server_launch.py
@@ -23,26 +23,8 @@ def generate_launch_description():
 
     with open(crazyflies_yaml, 'r') as ymlfile:
         crazyflies = yaml.safe_load(ymlfile)
-
-    crazyflies_types_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'crazyflie_types.yaml')
-
-    with open(crazyflies_types_yaml, 'r') as ymlfile:
-        crazyflie_types = yaml.safe_load(ymlfile)
-
-    server_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'crazyflie_server.yaml')
-
-    with open(server_yaml, 'r') as ymlfile:
-        server_params = yaml.safe_load(ymlfile)
-    
-    server_params = server_params["/crazyflie_server"]["ros__parameters"]
-    server_params["crazyflies"] = crazyflies
-    server_params["crazyflie_types"] = crazyflie_types
+        
+    server_params = crazyflies
 
 
     crazyflie_node = launch_ros.actions.Node(

--- a/crazyflie_server_py/launch/server_launch.py
+++ b/crazyflie_server_py/launch/server_launch.py
@@ -21,13 +21,16 @@ def generate_launch_description():
         'config',
         'crazyflie_server.yaml')
 
+    with open(server_yaml, 'r') as ymlfile:
+        server_params = yaml.safe_load(ymlfile)
+    server_params = server_params["/crazyflie_server"]["ros__parameters"]
 
     crazyflie_node = launch_ros.actions.Node(
         package="crazyflie_server_py",
         executable="crazyflie_server",
         output="screen",
         emulate_tty=True,
-        parameters=[server_yaml]
+        parameters=[server_params]
     )
 
 

--- a/crazyflie_server_py/launch/server_launch.py
+++ b/crazyflie_server_py/launch/server_launch.py
@@ -16,6 +16,22 @@ import xacro
 def generate_launch_description():
 
     # construct crazyswarm2_server configuration
+    crazyflies_yaml = os.path.join(
+        get_package_share_directory('crazyflie'),
+        'config',
+        'crazyflies.yaml')
+
+    with open(crazyflies_yaml, 'r') as ymlfile:
+        crazyflies = yaml.safe_load(ymlfile)
+
+    crazyflies_types_yaml = os.path.join(
+        get_package_share_directory('crazyflie'),
+        'config',
+        'crazyflie_types.yaml')
+
+    with open(crazyflies_types_yaml, 'r') as ymlfile:
+        crazyflie_types = yaml.safe_load(ymlfile)
+
     server_yaml = os.path.join(
         get_package_share_directory('crazyflie'),
         'config',
@@ -23,7 +39,11 @@ def generate_launch_description():
 
     with open(server_yaml, 'r') as ymlfile:
         server_params = yaml.safe_load(ymlfile)
+    
     server_params = server_params["/crazyflie_server"]["ros__parameters"]
+    server_params["crazyflies"] = crazyflies
+    server_params["crazyflie_types"] = crazyflie_types
+
 
     crazyflie_node = launch_ros.actions.Node(
         package="crazyflie_server_py",

--- a/crazyflie_server_py/launch/server_launch.py
+++ b/crazyflie_server_py/launch/server_launch.py
@@ -14,14 +14,22 @@ import xacro
 
 
 def generate_launch_description():
-    pkg_share = get_package_share_directory("crazyflie_server_py")
+
+    # construct crazyswarm2_server configuration
+    server_yaml = os.path.join(
+        get_package_share_directory('crazyswarm2'),
+        'config',
+        'crazyswarm2_server.yaml')
+
 
     crazyflie_node = launch_ros.actions.Node(
         package="crazyflie_server_py",
         executable="crazyflie_server",
         output="screen",
         emulate_tty=True,
+        parameters=[server_yaml]
     )
+
 
     ld = LaunchDescription()
     ld.add_action(crazyflie_node)

--- a/crazyflie_server_py/launch/server_launch.py
+++ b/crazyflie_server_py/launch/server_launch.py
@@ -17,9 +17,9 @@ def generate_launch_description():
 
     # construct crazyswarm2_server configuration
     server_yaml = os.path.join(
-        get_package_share_directory('crazyswarm2'),
+        get_package_share_directory('crazyflie'),
         'config',
-        'crazyswarm2_server.yaml')
+        'crazyflie_server.yaml')
 
 
     crazyflie_node = launch_ros.actions.Node(


### PR DESCRIPTION
Hi!

This is the crazyflie python server with parameter handling as discussed in #44.

It checks the parameter framework and checks if there are any assigned first in crazyflie_server (`firmware_params`) then in crazyflie_types (`crazyflie_types. (...) .firmware_params`) and then in crazyflies (`crazyflies. (...). firmware_params`). So the parameter handling gives the priority order like this:
1. individual parameter crazyflie parameters
2. Crazyflie types parameters
3. Crazyflie server parameters. 

Then it converts all the remaining crazyflie parameters to ROS parameters, for now only at startup but I want to add dynamic parameter changing to it as well in the next commits.

Some questions related to this draft PR for @whoenig:
1. It seems that the ROS2 parameter structure uses dots for paramters instead of dashes so I keep that constant. However, the cpp version of the crazyflie servers uses dashes. What shall we use within Crazyswarm
2. For dynamic updating the Crazyflie parameters, do we still want to keep the priority list, or change it regardless? For instance, if one crazyflie has stabilizer.controller = 2 at startup but while the node is running, we change the firmware.stabilizer.controller to 1, should all crazyflies regardless of their startup yaml values update the controller to 1?
3. (Edited) For dynamic updating, do we want to also check for crazyflie parameters updates too or keep the ros2 parameter framework as master. get_value of the cflib is giving some thread handling issues though.

Also currently I'm initializing the node with  `allow_undeclared_parameters=True,    automatically_declare_parameters_from_overrides=True,`, which is the only way to work with undeclared parameters at this point. Another way is to access the self._parameters property of the node, which doesn't seem like it should be touched either... Not ideal but perhaps okay for now to keep using those flags, I guess they haven't removed those for a reason. 

(btw, the commits are suggesting that I worked on this 4 days ago, but I had to rebase it all on the name changes recently :) been working on this for a bit longer than that. )
