### PR TITLE
Py server logging blocks

### DIFF
--- a/crazyflie/config/crazyflies.yaml
+++ b/crazyflie/config/crazyflies.yaml
@@ -2,21 +2,38 @@
 robots:
   cf231:
     enabled: true
-    uri: radio://0/80/2M/E7E7E7E7E7
+    uri: radio://0/40/2M/E7E7E7E701
     initial_position: [0, 0, 0]
     type: cf21  # see robot_types
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
+    firmware_logging:
+      enabled: true
+      default_topics:
+        pose:
+          frequency:  5 # Hz
+      custom_topics:
+        topic_name3: 
+          frequency: 1
+          vars: ["acc.x", "acc.y"]
   cf5:
-    enabled: false
-    uri: radio://0/80/2M/E7E7E7E705
+    enabled: true
+    uri: radio://0/40/2M/E7E7E7E703
     initial_position: [0, -0.5, 0]
     type: cf21  # see robot_types
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
-
+    firmware_logging:
+      enabled: true
+      default_topics:
+        pose:
+          frequency:  5 # Hz
+      custom_topics:
+        topic_name3: 
+          frequency: 1
+          vars: ["acc.x", "acc.y", "acc.z"]
 # Definition of the various robot types
 robot_types:
   cf21:
@@ -32,6 +49,15 @@ robot_types:
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
+    #firmware_logging:
+      #enabled: true
+      #default_topics:
+      #  pose:
+      #    frequency: 1 # Hz
+    #  custom_topics:
+    #    topic_name3: 
+    #      frequency: 1
+    #      vars: ["acc.x", "acc.y", "acc.z"]
 
   cf21_mocap_deck:
     motion_capture:
@@ -43,6 +69,7 @@ robot_types:
     battery:
       voltage_warning: 3.8  # V
       voltage_critical: 3.7 # V
+
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
@@ -52,15 +79,18 @@ all:
   # firmware parameters for all drones (use robot_types/type_name to set per type, or
   # robots/drone_name to set per drone)
   firmware_logging:
-    enabled: true
+    enabled: false
     default_topics:
      # remove to disable default topic
-     pose:
+      pose:
         frequency: 10 # Hz
     custom_topics:
       topic_name1:
         frequency: 10 # Hz
         vars: ["stateEstimateZ.x", "stateEstimateZ.y", "stateEstimateZ.z", "pm.vbat"]
+      topic_name2:
+        frequency: 1 # Hz
+        vars: ["stabilizer.roll", "stabilizer.pitch", "stabilizer.yaw"]
   firmware_params:
     commander:
       enHighLevel: 1

--- a/crazyflie/config/crazyflies.yaml
+++ b/crazyflie/config/crazyflies.yaml
@@ -2,38 +2,31 @@
 robots:
   cf231:
     enabled: true
-    uri: radio://0/40/2M/E7E7E7E701
+    uri: radio://0/80/2M/E7E7E7E7E7
     initial_position: [0, 0, 0]
     type: cf21  # see robot_types
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
-    firmware_logging:
-      enabled: true
-      default_topics:
-        pose:
-          frequency:  5 # Hz
-      custom_topics:
-        topic_name3: 
-          frequency: 1
-          vars: ["acc.x", "acc.y"]
+    # firmware_logging:
+    #   enabled: true
+    #   custom_topics:
+    #     topic_name3: 
+    #       frequency: 1
+    #       vars: ["acc.x", "acc.y"]
   cf5:
-    enabled: true
-    uri: radio://0/40/2M/E7E7E7E703
+    enabled: false
+    uri: radio://0/80/2M/E7E7E7E705
     initial_position: [0, -0.5, 0]
     type: cf21  # see robot_types
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
-    firmware_logging:
-      enabled: true
-      default_topics:
-        pose:
-          frequency:  5 # Hz
-      custom_topics:
-        topic_name3: 
-          frequency: 1
-          vars: ["acc.x", "acc.y", "acc.z"]
+    #firmware_logging:
+    #  custom_topics:
+    #    topic_name3: 
+    #      frequency: 1
+    #      vars: ["acc.x", "acc.y", "acc.z"]
 # Definition of the various robot types
 robot_types:
   cf21:
@@ -50,11 +43,11 @@ robot_types:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
     #firmware_logging:
-      #enabled: true
-      #default_topics:
-      #  pose:
-      #    frequency: 1 # Hz
-    #  custom_topics:
+    #   enabled: true
+    #   default_topics:
+    #   pose:
+    #     frequency: 1 # Hz
+    #   custom_topics:
     #    topic_name3: 
     #      frequency: 1
     #      vars: ["acc.x", "acc.y", "acc.z"]
@@ -84,13 +77,13 @@ all:
      # remove to disable default topic
       pose:
         frequency: 10 # Hz
-    custom_topics:
-      topic_name1:
-        frequency: 10 # Hz
-        vars: ["stateEstimateZ.x", "stateEstimateZ.y", "stateEstimateZ.z", "pm.vbat"]
-      topic_name2:
-        frequency: 1 # Hz
-        vars: ["stabilizer.roll", "stabilizer.pitch", "stabilizer.yaw"]
+    #custom_topics:
+    #  topic_name1:
+    #    frequency: 10 # Hz
+    #    vars: ["stateEstimateZ.x", "stateEstimateZ.y", "stateEstimateZ.z", "pm.vbat"]
+    #  topic_name2:
+    #    frequency: 1 # Hz
+    #    vars: ["stabilizer.roll", "stabilizer.pitch", "stabilizer.yaw"]
   firmware_params:
     commander:
       enHighLevel: 1

--- a/crazyflie/config/crazyflies.yaml
+++ b/crazyflie/config/crazyflies.yaml
@@ -51,6 +51,16 @@ robot_types:
 all:
   # firmware parameters for all drones (use robot_types/type_name to set per type, or
   # robots/drone_name to set per drone)
+  firmware_logging:
+    enabled: true
+    default_topics:
+     # remove to disable default topic
+     pose:
+        frequency: 10 # Hz
+    custom_topics:
+      topic_name1:
+        frequency: 10 # Hz
+        vars: ["stateEstimateZ.x", "stateEstimateZ.y", "stateEstimateZ.z", "pm.vbat"]
   firmware_params:
     commander:
       enHighLevel: 1

--- a/crazyflie_interfaces/CMakeLists.txt
+++ b/crazyflie_interfaces/CMakeLists.txt
@@ -35,6 +35,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/UpdateParams.srv"
   "srv/UploadTrajectory.srv"
   "srv/RemoveLogging.srv"
+  "srv/AddLogging.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs 
   ADD_LINTER_TESTS
 )

--- a/crazyflie_interfaces/CMakeLists.txt
+++ b/crazyflie_interfaces/CMakeLists.txt
@@ -34,6 +34,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/Takeoff.srv"
   "srv/UpdateParams.srv"
   "srv/UploadTrajectory.srv"
+  "srv/RemoveLogging.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs 
   ADD_LINTER_TESTS
 )

--- a/crazyflie_interfaces/srv/AddLogging.srv
+++ b/crazyflie_interfaces/srv/AddLogging.srv
@@ -2,3 +2,4 @@ string topic_name
 int32 frequency
 string[] vars
 ---
+bool success

--- a/crazyflie_interfaces/srv/AddLogging.srv
+++ b/crazyflie_interfaces/srv/AddLogging.srv
@@ -1,0 +1,4 @@
+string topic_name
+int32 frequency
+string[] vars
+---

--- a/crazyflie_interfaces/srv/RemoveLogging.srv
+++ b/crazyflie_interfaces/srv/RemoveLogging.srv
@@ -1,2 +1,3 @@
 string topic_name
 ---
+bool success

--- a/crazyflie_interfaces/srv/RemoveLogging.srv
+++ b/crazyflie_interfaces/srv/RemoveLogging.srv
@@ -1,0 +1,2 @@
+string topic_name
+---

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -54,6 +54,15 @@ class CrazyflieServer(Node):
         self.swarm = Swarm(self.uris, factory=factory)
         self.swarm.fully_connected_crazyflie_cnt = 0
         self.swarm.all_fully_connected = False
+        self.swarm.log_topics = []
+
+        for param_name, param in self._parameters.items():
+            param_name_split = param_name.split('.')
+            if param_name_split[0] == "all_robots":
+                if param_name_split[1] == "log_topics":
+                    print(param.value)
+                    self.swarm.log_topics.append(param.value)
+            
         for link_uri in self.uris:
             self.swarm._cfs[link_uri].cf.fully_connected.add_callback(
                 self._fully_connected

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -54,10 +54,12 @@ class CrazyflieServer(Node):
         self.swarm = Swarm(self.uris, factory=factory)
         self.swarm.fully_connected_crazyflie_cnt = 0
         self.swarm.all_fully_connected = False
-        self.swarm.log_topics = []
 
+        self.swarm.custom_log_topics = {}
         self._pose_logging_enabled = False
         self._pose_logging_freq = 10
+        
+        temp_log_dict = {"frequency":0,"vars": "" }
 
         for param_name, param in self._parameters.items():
             param_name_split = param_name.split('.')
@@ -66,6 +68,14 @@ class CrazyflieServer(Node):
                     if param_name_split[3] == "pose":
                         self.pose_logging_enabled = True
                         self.pose_logging_freq = param.value
+                if param_name_split[2] == "custom_topics":
+                    if param_name_split[4]== "frequency":
+                        temp_log_dict.update({"frequency":param.value})
+                    if param_name_split[4]== "vars":
+                        temp_log_dict.update({"vars":param.value})
+                    if temp_log_dict["frequency"] != 0 and temp_log_dict["vars"] != "":
+                       self.swarm.custom_log_topics[param_name_split[3]] = temp_log_dict
+                       temp_log_dict = {"frequency":0,"vars": "" }
 
             
         for link_uri in self.uris:

--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -69,6 +69,9 @@ class CrazyflieServer(Node):
         self.swarm.custom_log_topics = {}
         self._pose_logging_enabled = False
         self._pose_logging_freq = 10
+
+
+        self.ros_parameters = self.param_to_dict(self._parameters)
         
         temp_log_dict = {"frequency":0,"vars": [] }
 
@@ -176,6 +179,20 @@ class CrazyflieServer(Node):
             self.create_subscription(
                 Twist, name + "/cmd_vel", partial(self._cmd_vel_changed, uri=uri), 10
             )
+
+    def param_to_dict(self, param_ros):
+        tree = {}
+
+        for item in param_ros:
+            t = tree
+            for part in item.split('.'):
+                if part == item.split('.')[-1]:
+                    t = t.setdefault(part, param_ros[item].value)
+                else:
+                    t = t.setdefault(part, {})
+
+        return tree
+ 
 
 
     def _fully_connected(self, link_uri):

--- a/crazyflie_server_py/package.xml
+++ b/crazyflie_server_py/package.xml
@@ -9,6 +9,9 @@
 
   <exec_depend>tf-transformations</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/crazyflie_server_py/package.xml
+++ b/crazyflie_server_py/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="kimberly@bitcraze.io">Kimberly McGuire</maintainer>
   <license>MIT</license>
 
+  <exec_depend>tf-transformations</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Hi!

Let's just see how this go since this is a nice way to check the process I think. As long as the PR is on draft you don't get many notifications right @whoenig ?

Anyway, I'm currently working on implementing the logging framework in the cfilb server based on the discussion in #56. For now only the default logging is Pose, and more custom logging can be added. I figured out that I could use the self._parameter, which is supposed to be private but thanks to python it is still open. So I'm currently using that for the intialization of the log blocks. 

This will be probably still a week work to finish I think? I'll update next week how it goes. 

UPDATE:
The PR is ready for review now. These are the features:

- It is able to determine default topics (only Pose for now) and custom topics from ROS2 parameters
- Based on the ROS parameters for logging, it sets up logblocks for the crazyflie and publishes each variable on ROS2 topics seperately
- Two services: one to add a log block (/add_logging) and one to remove it (/remove_logging)
- For every logblock there is active, a 'cf_name'/log/'block_name/*' is set up parameter. This is also so that the user knows which block to remove later dynamically
