### PR TITLE
Add missing services py server

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -598,37 +598,14 @@ class CrazyflieServer(Node):
 
     def _notify_setpoints_stop_callback(self, request, response, uri="all"):
         self.get_logger().info("Notify setpoint stop not yet implemented")
-        response.success = False
         return response
 
     def _upload_trajectory_callback(self, request, response, uri="all"):
         self.get_logger().info("Notify trajectory not yet implemented")
-        response.success = False
         return response
     
     def _start_trajectory_callback(self, request, response, uri="all"):
-        self.get_logger().info("start_trajectory(id=%d, timescale=%f, reversed=%d, relative=%d, group_mask=%d)"%
-            (request.trajectory_id,
-            request.timescale,
-            request.reversed,
-            request.relative,
-            request.group_mask))
-
-        if uri == "all":
-            for link_uri in self.uris:
-                self.swarm._cfs[link_uri].cf.high_level_commander.start_trajectory(request.trajectory_id, 
-                    time_scale = request.timescale, 
-                    reversed = request.reversed,
-                    relative = request.relative,
-                    group_mask=request.group_mask)
-        else:
-            self.swarm._cfs[uri].cf.high_level_commander.start_trajectory(
-                request.trajectory_id,
-                time_scale = request.timescale,
-                reversed = request.reversed,
-                relative = request.relative,
-                group_mask=request.group_mask
-            )
+        self.get_logger().info("Start trajectory not yet implemented")
         return response
 
     def _cmd_vel_changed(self, msg, uri=""):

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -18,7 +18,7 @@ from cflib.crazyflie.swarm import Swarm
 from cflib.crazyflie.log import LogConfig
 
 from crazyflie_interfaces.srv import Takeoff, Land, GoTo, RemoveLogging, AddLogging
-from crazyflie_interfaces.srv import UploadTrajectory, StartTrajectory
+from crazyflie_interfaces.srv import UploadTrajectory, StartTrajectory, NotifySetpointsStop
 from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult, ParameterType
 
 from std_srvs.srv import Empty
@@ -241,6 +241,9 @@ class CrazyflieServer(Node):
             )
             self.create_service(
                 UploadTrajectory, name + "/upload_trajectory", partial(self._upload_trajectory_callback, uri=uri) 
+            )
+            self.create_service(
+                NotifySetpointsStop, name + "/notify_setpoints_stop", partial(self._notify_setpoints_stop_callback, uri=uri) 
             )
             self.create_subscription(
                 Twist, name +
@@ -593,8 +596,13 @@ class CrazyflieServer(Node):
             )
         return response
 
+    def _notify_setpoints_stop_callback(self, request, response, uri="all"):
+        self.get_logger().info("Notify setpoint stop not yet implemented")
+        response.success = False
+        return response
+
     def _upload_trajectory_callback(self, request, response, uri="all"):
-        self.get_logger().info("Upload trajectory not yet implemented")
+        self.get_logger().info("Notify trajectory not yet implemented")
         response.success = False
         return response
     

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -17,7 +17,8 @@ from cflib.crazyflie.swarm import CachedCfFactory
 from cflib.crazyflie.swarm import Swarm
 from cflib.crazyflie.log import LogConfig
 
-from crazyflie_interfaces.srv import Takeoff, Land, GoTo, RemoveLogging, AddLogging, StartTrajectory
+from crazyflie_interfaces.srv import Takeoff, Land, GoTo, RemoveLogging, AddLogging
+from crazyflie_interfaces.srv import UploadTrajectory, StartTrajectory
 from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult, ParameterType
 
 from std_srvs.srv import Empty
@@ -237,6 +238,9 @@ class CrazyflieServer(Node):
             )
             self.create_service(
                 StartTrajectory, name + "/start_trajectory", partial(self._start_trajectory_callback, uri=uri)
+            )
+            self.create_service(
+                UploadTrajectory, name + "/upload_trajectory", partial(self._upload_trajectory_callback, uri=uri) 
             )
             self.create_subscription(
                 Twist, name +
@@ -587,6 +591,11 @@ class CrazyflieServer(Node):
                 relative=request.relative,
                 group_mask=request.group_mask,
             )
+        return response
+
+    def _upload_trajectory_callback(self, request, response, uri="all"):
+        self.get_logger().info("Upload trajectory not yet implemented")
+        response.success = False
         return response
     
     def _start_trajectory_callback(self, request, response, uri="all"):


### PR DESCRIPTION
I noticed that the cflib backend was missing services, namely upload trajectory, start trajectory and stop setpoint notification. This prevented the crazyflie API to start up properly and none of the crazyflie examples worked.

For now, the upload/start trajectory and stop setpoint notifications are dummy services that return a failed completed service. But the service reactions will be implemented soon within a new PR. At least this makes the helloworld script work again