### PR TITLE
add transform for pose

### DIFF
--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -68,3 +68,32 @@ In the second terminal
 .. code-block:: bash
 
     ros2 run crazyflie_examples hello_world
+
+RVIZ2 Pose Vizualization (Only CFlib backend)
+~~~~~~~~~~~~~~
+
+In crazyflie.yaml, make sure that this following is added or uncommented
+
+.. code-block:: bash
+    all:
+    ...
+    firmware_logging:
+        enabled: true
+        default_topics:
+        pose:
+            frequency: 10 # Hz
+
+In the first terminal, launch
+
+.. code-block:: bash
+
+    ros2 launch crazyflie launch.py backend:=cflib
+
+In the second terminal
+
+.. code-block:: bash
+
+    rviz2
+
+Then set 'fixed frame' to 'world' and add the TF plugin. Then in 'TF', check  the 'show names' checkbox.
+The crazyflie names should appear with their estimated position.

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -78,6 +78,7 @@ RVIZ2 Pose
 In crazyflie.yaml, make sure that this following is added or uncommented
 
 .. code-block:: bash
+    
     all:
     ...
     firmware_logging:

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -69,8 +69,11 @@ In the second terminal
 
     ros2 run crazyflie_examples hello_world
 
-RVIZ2 Pose Vizualization (Only CFlib backend)
-~~~~~~~~~~~~~~
+Vizualization
+-------------
+
+RVIZ2 Pose
+~~~~~~~~~~
 
 In crazyflie.yaml, make sure that this following is added or uncommented
 
@@ -83,7 +86,7 @@ In crazyflie.yaml, make sure that this following is added or uncommented
         pose:
             frequency: 10 # Hz
 
-In the first terminal, launch
+In the first terminal, launch the server (CFlib backend only for now)
 
 .. code-block:: bash
 


### PR DESCRIPTION
If enabled_pose is set to true in crazyflies.yaml, the Crazyflie pose transform is now broadcasted.

```ros2 launch crazyflie backend:=cflib```

other terminal

```rviz2```

change 'fixed frame' to world, and add an 'TF' to the vizualiation. The crazyflies should be seen per name in rviz now. 
