### PR TITLE
Hover command twist

### DIFF
--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -62,7 +62,7 @@ def generate_launch_description():
                 ('emergency', 'all/emergency'),
                 ('takeoff', 'cf6/takeoff'),
                 ('land', 'cf6/land'),
-                ('cmd_vel', 'cf6/cmd_vel'),
+                ('cmd_vel_legacy', 'cf6/cmd_vel_legacy'),
                 ('cmd_full_state', 'cf6/cmd_full_state'),
                 ('notify_setpoints_stop', 'cf6/notify_setpoints_stop'),
             ],

--- a/crazyflie/launch/launch_teleop2.py
+++ b/crazyflie/launch/launch_teleop2.py
@@ -62,7 +62,7 @@ def generate_launch_description():
             remappings=[
                 ('takeoff', 'cf231/takeoff'),
                 ('land', 'cf231/land'),
-                ('cmd_vel', 'cf231/cmd_vel'),
+                ('cmd_vel_legacy', 'cf231/cmd_vel_legacy'),
                 ('cmd_full_state', 'cf231/cmd_full_state'),
                 ('notify_setpoints_stop', 'cf231/notify_setpoints_stop'),
                 ('joy', 'cf231/joy'),
@@ -76,7 +76,7 @@ def generate_launch_description():
             remappings=[
                 ('takeoff', 'cf5/takeoff'),
                 ('land', 'cf5/land'),
-                ('cmd_vel', 'cf5/cmd_vel'),
+                ('cmd_vel_legacy', 'cf5/cmd_vel_legacy'),
                 ('cmd_full_state', 'cf5/cmd_full_state'),
                 ('notify_setpoints_stop', 'cf5/notify_setpoints_stop'),
                 ('joy', 'cf5/joy'),

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -234,7 +234,7 @@ class CrazyflieServer(Node):
             )
             self.create_subscription(
                 Twist, name +
-                "/cmd_vel", partial(self._cmd_vel_changed, uri=uri), 10
+                "/cmd_vel_legacy", partial(self._cmd_vel_legacy_changed, uri=uri), 10
             )
 
     def _init_default_logblocks(self, prefix, link_uri, list_logvar, global_logging_enabled, topic_type):
@@ -725,7 +725,7 @@ class CrazyflieServer(Node):
         self.get_logger().info("Start trajectory not yet implemented")
         return response
 
-    def _cmd_vel_changed(self, msg, uri=""):
+    def _cmd_vel_legacy_changed(self, msg, uri=""):
         """
         Topic update callback to control the attitude and thrust
             of the crazyflie with teleop

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -236,6 +236,10 @@ class CrazyflieServer(Node):
                 Twist, name +
                 "/cmd_vel_legacy", partial(self._cmd_vel_legacy_changed, uri=uri), 10
             )
+            self.create_subscription(
+                Twist, name +
+                "/cmd_vel_2d", partial(self._cmd_vel_2d_changed, uri=uri), 10
+            )
 
     def _init_default_logblocks(self, prefix, link_uri, list_logvar, global_logging_enabled, topic_type):
         """
@@ -736,6 +740,18 @@ class CrazyflieServer(Node):
         thrust = int(min(max(msg.linear.z, 0, 0), 60000))
         self.swarm._cfs[uri].cf.commander.send_setpoint(
             roll, pitch, yawrate, thrust)
+
+    def _cmd_vel_2d_changed(self, msg, uri=""):
+        """
+        Topic update callback to control the 2d velocity and thrust
+            of the crazyflie with teleop
+        """
+        vx = msg.linear.y
+        vy = msg.linear.x
+        z = msg.linear.z
+        yawrate = msg.angular.z
+        self.swarm._cfs[uri].cf.commander.send_hover_setpoint(
+            vx, vy, yawrate, z)
 
     def _remove_logging(self, request, response, uri="all"):
         """

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -258,14 +258,12 @@ class CrazyflieServer(Node):
         for uri in self.cf_dict:
             height = self.swarm._cfs[uri].cmd_vel_2d['current_height']
             if height<0.2:
-                self.get_logger().info(" not during takeoff")
                 return
             timestamp = self.swarm._cfs[uri].cmd_vel_2d['timestamp']
 
             if time.time() < timestamp + 0.5:
                 msg = self.swarm._cfs[uri].cmd_vel_2d['msg']
 
-                self.get_logger().info('send hovercommand')
                 vx = msg.linear.y
                 vy = msg.linear.x
                 yawrate = msg.angular.z
@@ -274,7 +272,7 @@ class CrazyflieServer(Node):
                 self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] = False
             else:
                 if self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] == False:
-                    self.get_logger().info('send pos hold')
+                    self.get_logger().info(f'{uri}: Sent Position hold')
 
                     self.swarm._cfs[uri].cf.high_level_commander.go_to(0,0,0,0,0,relative=1)
                     self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] = True

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -262,6 +262,8 @@ class CrazyflieServer(Node):
             timestamp = self.swarm._cfs[uri].cmd_vel_2d['timestamp']
 
             if time.time() < timestamp + 0.5:
+                self.get_logger().info(f'{uri}: Received 2d twist message')
+
                 msg = self.swarm._cfs[uri].cmd_vel_2d['msg']
 
                 vx = msg.linear.y

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -11,6 +11,7 @@ A crazyflie server for communicating with several crazyflies
 
 import rclpy
 from rclpy.node import Node
+import time
 
 import cflib.crtp
 from cflib.crazyflie.swarm import CachedCfFactory
@@ -33,6 +34,8 @@ from tf2_ros import TransformBroadcaster
 
 from functools import partial
 from math import radians, pi, cos, sin
+
+FIX_HEIGHT_CMD_VEL_2D = False
 
 cf_log_to_ros_topic = {
     "uint8_t": UInt8,
@@ -107,6 +110,13 @@ class CrazyflieServer(Node):
 
         # Initialize logging, services and parameters for each crazyflie
         for link_uri in self.uris:
+            
+            # Only used for the pos hold mode
+            self.swarm._cfs[link_uri].cmd_vel_2d = {}
+            self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] = True
+            self.swarm._cfs[uri].cmd_vel_2d['current_height'] = 0.0
+            self.swarm._cfs[uri].cmd_vel_2d['timestamp'] = 0.0
+            self.swarm._cfs[uri].cmd_vel_2d['msg'] = Twist
 
             # Connect callbacks for different connection states of the crazyflie
             self.swarm._cfs[link_uri].cf.fully_connected.add_callback(
@@ -240,6 +250,35 @@ class CrazyflieServer(Node):
                 Twist, name +
                 "/cmd_vel_2d", partial(self._cmd_vel_2d_changed, uri=uri), 10
             )
+        if FIX_HEIGHT_CMD_VEL_2D:
+            timer_period = 0.1
+            self.create_timer(timer_period, self.send_hover_command)
+
+    def send_hover_command(self):
+        for uri in self.cf_dict:
+            height = self.swarm._cfs[uri].cmd_vel_2d['current_height']
+            if height<0.2:
+                self.get_logger().info(" not during takeoff")
+                return
+            timestamp = self.swarm._cfs[uri].cmd_vel_2d['timestamp']
+
+            if time.time() < timestamp + 0.5:
+                msg = self.swarm._cfs[uri].cmd_vel_2d['msg']
+
+                self.get_logger().info('send hovercommand')
+                vx = msg.linear.y
+                vy = msg.linear.x
+                yawrate = msg.angular.z
+                self.swarm._cfs[uri].cf.commander.send_hover_setpoint(
+                    vx, vy, yawrate, height)
+                self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] = False
+            else:
+                if self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] == False:
+                    self.get_logger().info('send pos hold')
+
+                    self.swarm._cfs[uri].cf.high_level_commander.go_to(0,0,0,0,0,relative=1)
+                    self.swarm._cfs[uri].cmd_vel_2d['hold_pos'] = True
+
 
     def _init_default_logblocks(self, prefix, link_uri, list_logvar, global_logging_enabled, topic_type):
         """
@@ -643,10 +682,14 @@ class CrazyflieServer(Node):
                 self.swarm._cfs[link_uri].cf.high_level_commander.takeoff(
                     request.height, duration
                 )
+                self.swarm._cfs[link_uri].cmd_vel_2d['current_height'] = request.height
+
         else:
             self.swarm._cfs[uri].cf.high_level_commander.takeoff(
                 request.height, duration
             )
+            self.swarm._cfs[uri].cmd_vel_2d['current_height'] = request.height
+
 
         return response
 
@@ -667,10 +710,13 @@ class CrazyflieServer(Node):
                 self.swarm._cfs[link_uri].cf.high_level_commander.land(
                     request.height, duration, group_mask=request.group_mask
                 )
+                self.swarm._cfs[link_uri].cmd_vel_2d['current_height'] = request.height
         else:
             self.swarm._cfs[uri].cf.high_level_commander.land(
                 request.height, duration, group_mask=request.group_mask
             )
+            self.swarm._cfs[uri].cmd_vel_2d['current_height'] = request.height
+
 
         return response
 
@@ -746,12 +792,16 @@ class CrazyflieServer(Node):
         Topic update callback to control the 2d velocity and thrust
             of the crazyflie with teleop
         """
-        vx = msg.linear.y
-        vy = msg.linear.x
-        z = msg.linear.z
-        yawrate = msg.angular.z
-        self.swarm._cfs[uri].cf.commander.send_hover_setpoint(
-            vx, vy, yawrate, z)
+        self.swarm._cfs[uri].cmd_vel_2d['timestamp'] = time.time()
+        self.swarm._cfs[uri].cmd_vel_2d['msg'] = msg
+
+        if FIX_HEIGHT_CMD_VEL_2D is False:
+            vx = msg.linear.y
+            vy = msg.linear.x
+            z = msg.linear.z
+            yawrate = msg.angular.z
+            self.swarm._cfs[uri].cf.commander.send_hover_setpoint(
+                vx, vy, yawrate, z)
 
     def _remove_logging(self, request, response, uri="all"):
         """

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -104,7 +104,7 @@ public:
     service_upload_trajectory_ = node->create_service<UploadTrajectory>(name + "/upload_trajectory", std::bind(&CrazyflieROS::upload_trajectory, this, _1, _2));
     service_notify_setpoints_stop_ = node->create_service<NotifySetpointsStop>(name + "/notify_setpoints_stop", std::bind(&CrazyflieROS::notify_setpoints_stop, this, _1, _2));
 
-    subscription_cmd_vel_ = node->create_subscription<geometry_msgs::msg::Twist>(name + "/cmd_vel", rclcpp::SystemDefaultsQoS(), std::bind(&CrazyflieROS::cmd_vel_changed, this, _1));
+    subscription_cmd_vel_legacy_ = node->create_subscription<geometry_msgs::msg::Twist>(name + "/cmd_vel_legacy", rclcpp::SystemDefaultsQoS(), std::bind(&CrazyflieROS::cmd_vel_legacy_changed, this, _1));
     subscription_cmd_full_state_ = node->create_subscription<crazyflie_interfaces::msg::FullState>(name + "/cmd_full_state", rclcpp::SystemDefaultsQoS(), std::bind(&CrazyflieROS::cmd_full_state_changed, this, _1));
     subscription_cmd_position_ = node->create_subscription<crazyflie_interfaces::msg::Position>(name + "/cmd_position", rclcpp::SystemDefaultsQoS(), std::bind(&CrazyflieROS::cmd_position_changed, this, _1));
 
@@ -257,7 +257,7 @@ private:
     cf_.sendPositionSetpoint(x, y, z, yaw);
   }
 
-  void cmd_vel_changed(const geometry_msgs::msg::Twist::SharedPtr msg)
+  void cmd_vel_legacy_changed(const geometry_msgs::msg::Twist::SharedPtr msg)
   {
     float roll = msg->linear.y;
     float pitch = - (msg->linear.x);
@@ -457,7 +457,7 @@ private:
   std::shared_ptr<rclcpp::ParameterEventCallbackHandle> cb_handle_;
   // std::vector<std::shared_ptr<rclcpp::ParameterCallbackHandle>> cb_handles_;
 
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr subscription_cmd_vel_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr subscription_cmd_vel_legacy_;
   rclcpp::Subscription<crazyflie_interfaces::msg::FullState>::SharedPtr subscription_cmd_full_state_;
   rclcpp::Subscription<crazyflie_interfaces::msg::Position>::SharedPtr subscription_cmd_position_;
 };
@@ -789,7 +789,7 @@ public:
     m_serviceSetGroupMask = n.advertiseService(tf_prefix + "/set_group_mask", &CrazyflieROS::setGroupMask, this);
     m_serviceNotifySetpointsStop = n.advertiseService(tf_prefix + "/notify_setpoints_stop", &CrazyflieROS::notifySetpointsStop, this);
 
-    m_subscribeCmdVel = n.subscribe(tf_prefix + "/cmd_vel", 1, &CrazyflieROS::cmdVelChanged, this);
+    m_subscribeCmdVel = n.subscribe(tf_prefix + "/cmd_vel_legacy", 1, &CrazyflieROS::cmdVelChanged, this);
     m_subscribeCmdPosition = n.subscribe(tf_prefix + "/cmd_position", 1, &CrazyflieROS::cmdPositionSetpoint, this);
     m_subscribeCmdFullState = n.subscribe(tf_prefix + "/cmd_full_state", 1, &CrazyflieROS::cmdFullStateSetpoint, this);
     m_subscribeCmdVelocityWorld = n.subscribe(tf_prefix + "/cmd_velocity_world", 1, &CrazyflieROS::cmdVelocityWorldSetpoint, this);

--- a/crazyflie/src/teleop.cpp
+++ b/crazyflie/src/teleop.cpp
@@ -49,7 +49,7 @@ public:
         subscription_ = this->create_subscription<sensor_msgs::msg::Joy>(
             "joy", 1, std::bind(&TeleopNode::joyChanged, this, _1));
 
-        pub_cmd_vel_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+        pub_cmd_vel_legacy_ = this->create_publisher<geometry_msgs::msg::Twist>("cmd_vel_legacy", 10);
         pub_cmd_full_state_ = this->create_publisher<crazyflie_interfaces::msg::FullState>("cmd_full_state", 10);
 
         this->declare_parameter("frequency", 0);
@@ -152,7 +152,7 @@ private:
         }
 
         if (mode_ == "cmd_rpy") { 
-            pub_cmd_vel_->publish(twist_);
+            pub_cmd_vel_legacy_->publish(twist_);
         }
         if (mode_ == "cmd_vel_world") {   
 
@@ -283,7 +283,7 @@ private:
     rclcpp::Client<Takeoff>::SharedPtr client_takeoff_;
     rclcpp::Client<Land>::SharedPtr client_land_;
     rclcpp::Client<NotifySetpointsStop>::SharedPtr client_notify_setpoints_stop_;
-    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_cmd_vel_;
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_cmd_vel_legacy_;
     rclcpp::Publisher<crazyflie_interfaces::msg::FullState>::SharedPtr pub_cmd_full_state_;
     rclcpp::TimerBase::SharedPtr timer_;
     rclcpp::TimerBase::SharedPtr timer_takeoff_;

--- a/crazyflie_examples/crazyflie_examples/cmd_vel_2d.py
+++ b/crazyflie_examples/crazyflie_examples/cmd_vel_2d.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import numpy as np
+from pathlib import Path
+import time
+from crazyflie_py import *
+
+ 
+def executeCommand(timeHelper, cf, height, duration, rate=100,):
+
+
+    start_time = timeHelper.time()
+    while not timeHelper.isShutdown():
+        t = timeHelper.time() - start_time
+        if t > duration:
+            break
+
+        cf.cmdVelocity2D(0.0, 0.0, height, yawrate=0.2 )
+
+        timeHelper.sleepForRate(rate)
+
+
+def main():
+    swarm = Crazyswarm()
+    timeHelper = swarm.timeHelper
+    cf = swarm.allcfs.crazyflies[0]
+
+    rate = 30.0
+    duration = 3.0
+    Z = 0.5
+
+
+    cf.takeoff(targetHeight=Z, duration=Z+1.0)
+    timeHelper.sleep(Z+2.0)
+
+    executeCommand(timeHelper, cf, Z, duration, rate)
+
+    time.sleep(0.5) #Necessary for Cflib backend since this is not implemented yet
+    cf.notifySetpointsStop()
+    cf.land(targetHeight=0.03, duration=Z+1.0)
+    timeHelper.sleep(Z+2.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -18,7 +18,7 @@ import rclpy
 import rclpy.node
 import rowan
 from std_srvs.srv import Empty
-from geometry_msgs.msg import Point
+from geometry_msgs.msg import Point, Twist
 from rcl_interfaces.srv import SetParameters, ListParameters, GetParameterTypes
 from rcl_interfaces.msg import Parameter, ParameterValue, ParameterType
 from crazyflie_interfaces.srv import Takeoff, Land, GoTo, UploadTrajectory, StartTrajectory, NotifySetpointsStop
@@ -177,6 +177,10 @@ class Crazyflie:
         self.cmdPositionPublisher = node.create_publisher(Position, prefix + "/cmd_position", 1)
         self.cmdPositionMsg = Position()
         self.cmdPositionMsg.header.frame_id = "/world"
+
+
+        self.cmdVelocity2DPublisher = node.create_publisher(Twist, prefix + "/cmd_vel_2d", 1)
+        self.cmdVelocity2DMsg = Twist()
 
         # self.cmdVelocityWorldPublisher = rospy.Publisher(prefix + "/cmd_velocity_world", VelocityWorld, queue_size=1)
         # self.cmdVelocityWorldMsg = VelocityWorld()
@@ -617,6 +621,13 @@ class Crazyflie:
         self.cmdPositionMsg.z   = pos[2]
         self.cmdPositionMsg.yaw = yaw
         self.cmdPositionPublisher.publish(self.cmdPositionMsg)
+
+    def cmdVelocity2D(self, vx_body, vy_body, height, yawrate = 0.0):
+        self.cmdVelocity2DMsg.linear.x = vx_body
+        self.cmdVelocity2DMsg.linear.y = vy_body
+        self.cmdVelocity2DMsg.linear.z = height
+        self.cmdVelocity2DMsg.angular.z = yawrate
+        self.cmdVelocity2DPublisher.publish(self.cmdVelocity2DMsg)
 
     # def setLEDColor(self, r, g, b):
     #     """Sets the color of the LED ring deck.


### PR DESCRIPTION
This is part of this ticket #73 

These are the main features currently:
- cmd_vel is now renamed to cmd_vel_legacy (this should be the case for both the cflib and the cpp node).  This is based on the discussion of #45.
- There is now a new topic called cmd_vel_2d, which in the cflib backend sends send_hover_setpoint() to crazyflie while fixing the height. The name implies that it only controls the velocity in body of 2d
- There is an experimental define in the cflib backend called FIX_HEIGHT_CMD_VEL_2D = False. When this is put on True, there is more handling happening with the receivings of the /cmd_vel_2d. The crazyflie needs to have taken off first, then it will use the takeoff height, reacts on the twist messages for velocity commands, and do a pos_hold if the timestamp of the last message is over 0.5 minute. 


The later is a nice functionality but it needs to be fleshed out a bit more, so that is why I'm keeping it out of the yaml file even