### PR TITLE
Velocity hover handler

### DIFF
--- a/.github/workflows/ci-docs2.yml
+++ b/.github/workflows/ci-docs2.yml
@@ -16,6 +16,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt update
         sudo apt install texlive-latex-extra dvipng
         sudo pip3 install -U setuptools
         sudo pip3 install -U -r docs2/requirements.txt

--- a/crazyflie/CMakeLists.txt
+++ b/crazyflie/CMakeLists.txt
@@ -102,6 +102,7 @@ install(TARGETS
 install(PROGRAMS
   scripts/crazyflie_server.py
   scripts/chooser.py
+  scripts/vel_mux.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/crazyflie/package.xml
+++ b/crazyflie/package.xml
@@ -17,6 +17,8 @@
   <depend>geometry_msgs</depend>
   <depend>motion_capture_tracking_interfaces</depend>
 
+  <exec_depend>tf_transformations</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/crazyflie/scripts/vel_mux.py
+++ b/crazyflie/scripts/vel_mux.py
@@ -13,42 +13,52 @@ HEIGHT = 0.3
 class VelMux(Node):
     def __init__(self):
         super().__init__('vel_mux')
+        self.declare_parameter('hover_height', 0.5)
+        self.declare_parameter('robot_prefix', '/cf1')
+        self.declare_parameter('incoming_twist_topic', '/cmd_vel')
+
+        self.hover_height  = self.get_parameter('hover_height').value
+        robot_prefix  = self.get_parameter('robot_prefix').value
+        incoming_twist_topic  = self.get_parameter('incoming_twist_topic').value
+        
+        self.get_logger().info(f"Velocity Multiplexer set for {robot_prefix}"+
+                               f" with height {self.hover_height} m using the {incoming_twist_topic} topic")
+
+        print("PARAMETERS", self.hover_height, robot_prefix, incoming_twist_topic)
+
         self.subscription = self.create_subscription(
             Twist,
-            '/cmd_vel',
+            incoming_twist_topic,
             self.cmd_vel_callback,
             10)
         self.msg_cmd_vel = Twist()
         self.received_first_cmd_vel = False
-        prefix = '/cf1'
         timer_period = 0.1
         self.timer = self.create_timer(timer_period, self.timer_callback)
-        self.take_off_client = self.create_client(Takeoff, prefix + '/takeoff')
-        self.publisher_hover = self.create_publisher(Hover, prefix + '/cmd_hover', 10)
-        self.land_client = self.create_client(Land, prefix + '/land')
+        self.take_off_client = self.create_client(Takeoff, robot_prefix + '/takeoff')
+        self.publisher_hover = self.create_publisher(Hover, robot_prefix + '/cmd_hover', 10)
+        self.land_client = self.create_client(Land, robot_prefix + '/land')
         self.cf_has_taken_off = False
-
 
     def cmd_vel_callback(self, msg):
         self.msg_cmd_vel = msg
-        if self.received_first_cmd_vel is False:
+        # This is to handle the zero twist messages from teleop twist keyboard closing
+        # or else the crazyflie would constantly take off again.
+        msg_is_zero = msg.linear.x == 0.0 and msg.linear.y == 0.0 and msg.angular.z == 0.0 and msg.linear.z == 0.0
+        if  msg_is_zero is False and self.received_first_cmd_vel is False and msg.linear.z >= 0.0:
             self.received_first_cmd_vel = True
+            print('takeoff')
 
     def timer_callback(self):
         if self.received_first_cmd_vel and self.cf_has_taken_off is False:
-            print('take off!')
             req = Takeoff.Request()
-            req.height = HEIGHT
+            req.height = self.hover_height
             req.duration = rclpy.duration.Duration(seconds=2.0).to_msg()
-            self.future = self.take_off_client.call_async(req)
+            self.take_off_client.call_async(req)
             self.cf_has_taken_off = True
-            time.sleep(2.0)
-
-        print(self.msg_cmd_vel)
-        
+            time.sleep(2.0)        
         if self.received_first_cmd_vel and self.cf_has_taken_off:
             if self.msg_cmd_vel.linear.z >= 0:
-                print('send velocity commands')
                 msg = Hover()
                 msg.vx = self.msg_cmd_vel.linear.x
                 msg.vy = self.msg_cmd_vel.linear.y
@@ -56,12 +66,15 @@ class VelMux(Node):
                 msg.z_distance = HEIGHT
                 self.publisher_hover.publish(msg)
             else:
+                print('land')
                 req = Land.Request()
                 req.height = 0.1
                 req.duration = rclpy.duration.Duration(seconds=2.0).to_msg()
-                self.future = self.land_client.call_async(req)
+                self.land_client.call_async(req)
+                time.sleep(2.0)        
                 self.cf_has_taken_off = False
                 self.received_first_cmd_vel = False
+
 
 
 def main(args=None):

--- a/crazyflie/scripts/vel_mux.py
+++ b/crazyflie/scripts/vel_mux.py
@@ -2,26 +2,62 @@ import rclpy
 from rclpy.node import Node
 
 from geometry_msgs.msg import Twist
-
+from crazyflie_interfaces.srv import Takeoff, Land
+from crazyflie_interfaces.msg import Hover
 import time
 
-TIME_STOP_SEND_CMD = 0.1
+HEIGHT = 0.8
 
 class VelMux(Node):
     def __init__(self):
         super().__init__('vel_mux')
-        self.subscription_hp = self.create_subscription(
+        self.subscription = self.create_subscription(
             Twist,
             '/cmd_vel',
             self.cmd_vel_callback,
             10)
-        self.msg_cmd_vel = Twist
+        self.msg_cmd_vel = Twist()
         self.received_first_cmd_vel = False
+        prefix = '/cf2'
+        timer_period = 0.1
+        self.timer = self.create_timer(timer_period, self.timer_callback)
+        self.take_off_client = self.create_client(Takeoff, prefix + '/take_off')
+        self.publisher_hover = self.create_publisher(Hover, prefix + '/cmd_vel_hover/', 10)
+        self.land_client = self.create_client(Takeoff, prefix + '/land')
+
 
     def cmd_vel_callback(self, msg):
-        self.msg = msg
+        self.msg_cmd_vel = msg
         if self.received_first_cmd_vel is False:
             self.received_first_cmd_vel = True
+
+    def timer_callback(self):
+        if self.received_first_cmd_vel and self.cf_has_taken_off is False:
+            print('take off!')
+            req = Takeoff.request()
+            req.height = HEIGHT
+            req.duration = 2.0
+            self.future = self.take_off_client.call_async(req)
+            rclpy.spin_until_future_complete(self, self.future)
+            self.cf_has_taken_off = True
+        
+        if self.received_first_cmd_vel and self.cf_has_taken_off:
+            if self.msg_cmd_vel.linear.z >= 0:
+                print('send velocity commands')
+                msg = Hover()
+                msg.vx = self.msg_cmd_vel.linear.x
+                msg.vy = self.msg_cmd_vel.linear.y
+                msg.yaw_rate = self.msg_cmd_vel.angular.z
+                msg.z_distance = HEIGHT
+                self.publisher_hover.publish(msg)
+            else:
+                req = Land.request()
+                req.height = 0.1
+                req.duration = 2.0
+                self.future = self.land_client.call_async(req)
+                rclpy.spin_until_future_complete(self, self.future)
+                self.cf_has_taken_off = False
+
 
 def main(args=None):
     rclpy.init(args=args)
@@ -32,8 +68,6 @@ def main(args=None):
 
     vel_mux.destroy_node()
     rclpy.shutdown()
-
-
 
 if __name__ == '__main__':
     main()

--- a/crazyflie/scripts/vel_mux.py
+++ b/crazyflie/scripts/vel_mux.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import rclpy
 from rclpy.node import Node
 
@@ -6,7 +8,7 @@ from crazyflie_interfaces.srv import Takeoff, Land
 from crazyflie_interfaces.msg import Hover
 import time
 
-HEIGHT = 0.8
+HEIGHT = 0.3
 
 class VelMux(Node):
     def __init__(self):
@@ -18,12 +20,13 @@ class VelMux(Node):
             10)
         self.msg_cmd_vel = Twist()
         self.received_first_cmd_vel = False
-        prefix = '/cf2'
+        prefix = '/cf1'
         timer_period = 0.1
         self.timer = self.create_timer(timer_period, self.timer_callback)
-        self.take_off_client = self.create_client(Takeoff, prefix + '/take_off')
-        self.publisher_hover = self.create_publisher(Hover, prefix + '/cmd_vel_hover/', 10)
-        self.land_client = self.create_client(Takeoff, prefix + '/land')
+        self.take_off_client = self.create_client(Takeoff, prefix + '/takeoff')
+        self.publisher_hover = self.create_publisher(Hover, prefix + '/cmd_hover', 10)
+        self.land_client = self.create_client(Land, prefix + '/land')
+        self.cf_has_taken_off = False
 
 
     def cmd_vel_callback(self, msg):
@@ -34,12 +37,14 @@ class VelMux(Node):
     def timer_callback(self):
         if self.received_first_cmd_vel and self.cf_has_taken_off is False:
             print('take off!')
-            req = Takeoff.request()
+            req = Takeoff.Request()
             req.height = HEIGHT
-            req.duration = 2.0
+            req.duration = rclpy.duration.Duration(seconds=2.0).to_msg()
             self.future = self.take_off_client.call_async(req)
-            rclpy.spin_until_future_complete(self, self.future)
             self.cf_has_taken_off = True
+            time.sleep(2.0)
+
+        print(self.msg_cmd_vel)
         
         if self.received_first_cmd_vel and self.cf_has_taken_off:
             if self.msg_cmd_vel.linear.z >= 0:
@@ -51,12 +56,12 @@ class VelMux(Node):
                 msg.z_distance = HEIGHT
                 self.publisher_hover.publish(msg)
             else:
-                req = Land.request()
+                req = Land.Request()
                 req.height = 0.1
-                req.duration = 2.0
+                req.duration = rclpy.duration.Duration(seconds=2.0).to_msg()
                 self.future = self.land_client.call_async(req)
-                rclpy.spin_until_future_complete(self, self.future)
                 self.cf_has_taken_off = False
+                self.received_first_cmd_vel = False
 
 
 def main(args=None):

--- a/crazyflie/scripts/vel_mux.py
+++ b/crazyflie/scripts/vel_mux.py
@@ -1,0 +1,39 @@
+import rclpy
+from rclpy.node import Node
+
+from geometry_msgs.msg import Twist
+
+import time
+
+TIME_STOP_SEND_CMD = 0.1
+
+class VelMux(Node):
+    def __init__(self):
+        super().__init__('vel_mux')
+        self.subscription_hp = self.create_subscription(
+            Twist,
+            '/cmd_vel',
+            self.cmd_vel_callback,
+            10)
+        self.msg_cmd_vel = Twist
+        self.received_first_cmd_vel = False
+
+    def cmd_vel_callback(self, msg):
+        self.msg = msg
+        if self.received_first_cmd_vel is False:
+            self.received_first_cmd_vel = True
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    vel_mux = VelMux()
+
+    rclpy.spin(vel_mux)
+
+    vel_mux.destroy_node()
+    rclpy.shutdown()
+
+
+
+if __name__ == '__main__':
+    main()

--- a/crazyflie/scripts/vel_mux.py
+++ b/crazyflie/scripts/vel_mux.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 
+"""
+A Twist message handler that get incoming twist messages from 
+    external packages and handles proper takeoff, landing and
+    hover commands of connected crazyflie in the crazyflie_server
+    node
+
+    2022 - K. N. McGuire (Bitcraze AB)
+"""
 import rclpy
 from rclpy.node import Node
 

--- a/crazyflie_examples/launch/keyboard_velmux_launch.py
+++ b/crazyflie_examples/launch/keyboard_velmux_launch.py
@@ -1,0 +1,36 @@
+import os
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    # load crazyflies
+    crazyflies_yaml = os.path.join(
+        get_package_share_directory('crazyflie'),
+        'config',
+        'crazyflies.yaml')
+
+    with open(crazyflies_yaml, 'r') as ymlfile:
+        crazyflies = yaml.safe_load(ymlfile)
+
+    server_params = crazyflies
+
+    return LaunchDescription([
+        Node(
+            package='crazyflie',
+            executable='crazyflie_server.py',
+            name='crazyflie_server',
+            output='screen',
+            parameters=[server_params]
+        ),
+        Node(
+            package='crazyflie',
+            executable='vel_mux.py',
+            name='vel_mux',
+            output='screen',
+            parameters=[{"hover_height": 0.3},
+                        {"incoming_twist_topic": "/cmd_vel"},
+                        {"robot_prefix": "/cf1"}]
+        ),
+    ])

--- a/crazyflie_examples/setup.py
+++ b/crazyflie_examples/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
+import os
+from glob import glob
 
 package_name = 'crazyflie_examples'
 
@@ -11,6 +13,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        (os.path.join('share', package_name), glob('launch/*launch.py'))
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -48,6 +48,7 @@ Enabling Logblocks
 ~~~~~~~~~~~~~~~~~~
 
 In one terminal run
+
 .. code-block:: bash
 
     ros2 launch crazyflie launch.py backend:=cflib
@@ -69,8 +70,8 @@ To close the logblocks again, run:
     ros2 service call /cf2/remove_logging crazyflie_interfaces/srv/RemoveLogging "{topic_name: 'pose'}"
 
 
-Teleoperation
-~~~~~~~~~~~~~
+Teleoperation controller
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 We currently assume an XBox controller (the button mapping can be changed in teleop.yaml). It is possible to fly in different modes, including attitude-control and position-control (in which case any localization system can assist.)
 
@@ -78,6 +79,27 @@ We currently assume an XBox controller (the button mapping can be changed in tel
 
     ros2 launch crazyflie launch.py
 
+
+Teleoperation keyboard
+~~~~~~~~~~~~~~~~~~~~~~
+We have an example of the telop_twist_keyboard package working together with the crazyflie
+
+First make sure that the crazyflies.yaml has the right URI and if you are using the flowdeck, 
+set the controller to 1 (PID)
+
+Then, run the following launch file to start up the crazyflie server (CFlib):
+
+.. code-block:: bash
+
+    ros2 launch crazyflie_examples keyboard_velmux_launch.py
+
+in another terminal run:
+
+.. code-block:: bash
+
+    ros2 run teleop_twist_keyboard telop_twist_keyboard
+
+Use 't' to take off, and 'b' to land. For the rest, use the instructions of the telop package. 
 
 Python scripts
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
In  #75 I've included a twist message handler in the cflib backend of the crazyflie server, but this PR proposes another way.

It includes:
- crazyflie/scripts/vel_mux.py: an node that handles incoming twist messages by first letting the crazyflie take off properly, send Hover msgs for the crazyflie_server.py and also enable proper landing
- crazyflie/scripts/crazyflie_server.py: a new subscriber that listens to /cmd_hover, with the Hover message from crazyflie_interfaces. This uses the commander.send_hover_setpoints() functionality of the cflib. The old cmd_vel_2d command has been removed
- crazyflie_examples/launch/keyboard_teleop_velmux_launch.py: an example launch file that opens the cflib backend server and the vel_mux node, so that the crazyflie that is given to the parameters will react accordingly to incoming twist messages. 