### PR TITLE
tiny addition to installation doc

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -34,7 +34,8 @@ First Installation
 
     .. code-block:: bash
         
-        pip3 install cflib
+        pip3 install cflib transforms3d
+        sudo apt-get install ros-*DISTRO*-tf-transformations
 
 3. Set up your ROS2 workspace
 


### PR DESCRIPTION
insyteensy tiny installation instruction addition for the cflib. I'll just merge without as this only involves the cflib backend. 

Perhaps the tf-transformations will be also used for the cpp backend, but let's fix that once it has implemented. One way is to use the rosdep functionality for this instead