### PR TITLE
annotation compatibility with earlier python versions

### DIFF
--- a/crazyflie_sim/crazyflie_sim/crazyflie_sil.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_sil.py
@@ -6,6 +6,7 @@ Crazyflie Software-In-The-Loop Wrapper that uses the firmware Python bindings
 
     2022 - Wolfgang Hönig (TU Berlin)
 """
+from __future__ import annotations
 
 import numpy as np
 


### PR DESCRIPTION
Got the following error with galactic and python 3.8 when I tried out `ros2 launch crazyflie launch.py backend:=sim`


```
[crazyflie_server-4]     def uploadTrajectory(self, trajectoryId: int, pieceOffset: int, pieces: list[TrajectoryPolynomialPiece]):                                                                              
[crazyflie_server-4] TypeError: 'type' object is not subscriptable 
```

This incompatibility with  pythonversions before 3.9 should fix that by adding 
```
from __future__ import annotations
```