### PR TITLE
Unify logging cflib backend

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -27,26 +27,14 @@ from crazyflie_interfaces.msg import LogDataGeneric
 from std_srvs.srv import Empty
 from geometry_msgs.msg import Twist
 from geometry_msgs.msg import PoseStamped, TransformStamped
-from std_msgs.msg import UInt8, UInt16, UInt32, Int8, Int16, Int32, Float32
 from sensor_msgs.msg import LaserScan
 from nav_msgs.msg import Odometry
-
 
 import tf_transformations
 from tf2_ros import TransformBroadcaster
 
 from functools import partial
 from math import degrees, radians, pi, cos, sin
-
-# cf_log_to_ros_topic = {
-#     "uint8_t": UInt8,
-#     "uint16_t": UInt16,
-#     "uint32_t": UInt32,
-#     "int8_t": Int8,
-#     "int16_t": Int16,
-#     "int32_t": Int32,
-#     "float": Float32,
-# }
 
 cf_log_to_ros_param = {
     "uint8_t": ParameterType.PARAMETER_INTEGER,
@@ -352,12 +340,6 @@ class CrazyflieServer(Node):
             cf_handle.l_toc = cf.log.toc.toc
             if len(cf_handle.logging["custom_log_groups"]) != 0 and cf_handle.logging["enabled"]:
 
-                #for log_name in cf_handle.logging["custom_log_publisher"]:
-
-                #    log_type = cf.log.toc.toc[log_name.split(
-                #        '.')[0]][log_name.split('.')[1]].ctype
-
-
                 for log_group_name, log_group_dict in cf_handle.logging["custom_log_groups"].items():
                     self.swarm._cfs[link_uri].logging["custom_log_publisher"][log_group_name] = self.create_publisher(
                         LogDataGeneric, self.cf_dict[link_uri] + "/" + log_group_name, 10)
@@ -369,10 +351,6 @@ class CrazyflieServer(Node):
                         lg_custom.error_cb.add_callback(
                             self._log_error_callback)
                         lg_custom.start()
-                        #self.declare_parameter(
-                        #    self.cf_dict[link_uri] + "/logs/" + log_group_name + "/frequency/", log_group_dict['frequency'])
-                        #self.declare_parameter(
-                        #    self.cf_dict[link_uri] + "/logs/" + log_group_name + "/vars/", log_group_dict['vars'])
                     except KeyError as e:
                         self.get_logger().info(f'{link_uri}: Could not start log configuration,'
                                                '{} not found in TOC'.format(str(e)))
@@ -537,7 +515,7 @@ class CrazyflieServer(Node):
         for log_name in data:
             log_type = self.swarm._cfs[uri].l_toc[log_name.split(
                 '.')[0]][log_name.split('.')[1]].ctype
-            msg = LogDataGeneric() #cf_log_to_ros_topic[log_type]()
+            msg = LogDataGeneric() 
             msg.values.append(data.get(log_name))
 
         self.swarm._cfs[uri].logging["custom_log_publisher"][logconf.name].publish(
@@ -847,10 +825,6 @@ class CrazyflieServer(Node):
                     name=topic_name, period_in_ms=1000 / frequency)
                 for log_name in variables:
                     lg_custom.add_variable(log_name)
-                    #log_type = self.swarm._cfs[uri].cf.log.toc.toc[log_name.split(
-                    #    '.')[0]][log_name.split('.')[1]].ctype
-                    #self.swarm._cfs[uri].logging["custom_log_publisher"][log_name] = self.create_publisher(
-                    #    cf_log_to_ros_topic[log_type], self.cf_dict[uri] + "/" + log_name.split('.')[0] + "/" + log_name.split('.')[1], 10)
                 self.swarm._cfs[uri].logging["custom_log_publisher"][log_name] = self.create_publisher(
                     LogDataGeneric, self.cf_dict[uri] + "/" + topic_name, 10)
                 

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -337,6 +337,7 @@ class CrazyflieServer(Node):
                     callback_fnc = self.default_log_fnc[prefix]
                     self._init_default_logging(prefix, link_uri, callback_fnc)
             
+            # Start logging for costum logging blocks
             cf_handle.l_toc = cf.log.toc.toc
             if len(cf_handle.logging["custom_log_groups"]) != 0 and cf_handle.logging["enabled"]:
 

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -145,7 +145,7 @@ Enabling Logblocks at runtime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
-    This is currently only supported in the CFLIB backend of the server.
+    Runtime logblock enabling is currently only supported in the CFLIB backend of the server.
 
 Above we explained how to enable log blocks at startup, but what if you would like to enable or disable logging blocks in runtime?
 This section will show how to do that by using services


### PR DESCRIPTION
This unify the logging between the cpp and python backend of the crazyflie server. Instead of creating one topic per log variable, it now makes one topic per log group based on the LogDataGeneric msg in crazyswarm2 to reduce overhead. See the discussion here: #56 

For now it is in draft as I forgot my crazyflies at the office and working from home today 😅 So I'll test it out next week!