### PR TITLE
Fix slam example with fixed scan message and solved 3d odom 

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -499,7 +499,7 @@ class CrazyflieServer(Node):
         msg.header.frame_id = self.world_tf_name
         msg.pose.pose.position.x = x
         msg.pose.pose.position.y = y
-        msg.pose.pose.position.y = z
+        msg.pose.pose.position.z = z
         msg.pose.pose.orientation.x = q[0]
         msg.pose.pose.orientation.y = q[1]
         msg.pose.pose.orientation.z = q[2]
@@ -519,6 +519,7 @@ class CrazyflieServer(Node):
         t_base.child_frame_id = cf_name
         t_base.transform.translation.x = x
         t_base.transform.translation.y = y
+        t_base.transform.translation.z = z
         t_base.transform.rotation.x = q[0]
         t_base.transform.rotation.y = q[1]
         t_base.transform.rotation.z = q[2]

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -418,7 +418,7 @@ class CrazyflieServer(Node):
             right_range = float("inf")
         if back_range > max_range:
             back_range = float("inf")  
-        self.ranges = [back_range, left_range, front_range, right_range]
+        self.ranges = [back_range, right_range, front_range, left_range]
 
         msg = LaserScan()
         msg.header.stamp = self.get_clock().now().to_msg()

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -599,12 +599,12 @@ private:
       msg.range_min = 0.01;
       msg.range_max = max_range;
       msg.ranges.push_back(back_range);
-      msg.ranges.push_back(left_range);
-      msg.ranges.push_back(front_range);
       msg.ranges.push_back(right_range);
-      msg.angle_min = 0.5 * 2 * M_PI;
-      msg.angle_max = -0.5 * 2 * M_PI;
-      msg.angle_increment = -1.0 * M_PI / 2;
+      msg.ranges.push_back(front_range);
+      msg.ranges.push_back(left_range);
+      msg.angle_min = -0.5 * 2 * M_PI;
+      msg.angle_max = 0.25 * 2 * M_PI;
+      msg.angle_increment = 1.0 * M_PI / 2;
 
       publisher_scan_->publish(msg);
     }


### PR DESCRIPTION
So this PR fixes the slam example as that was broken.

- The scan message is now fixed as the slam_toolbox determines that there are 4 ranges now now ( closes #143)
- The odometry is now full 3d due to the 'FP16' functionality (see #130)

I still need to double check it in flight once I'm at the office

The only thing now is that we need to think about handling these special compressed types for the default custom messages. I want to use the compressed quaternion type anyway, as now I ended up rotating at every message receive anyway, but the logic only handles compressed floats at the moment for odom. But that is something that we can think about later. 