### PR TITLE
LogDataGeneric: float64 -> float32

### DIFF
--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -298,7 +298,7 @@ public:
 
             publishers_generic_.emplace_back(node->create_publisher<crazyflie_interfaces::msg::LogDataGeneric>(name + "/" + topic_name, 10));
 
-            std::function<void(uint32_t, std::vector<double>*, void* userData)> cb = std::bind(
+            std::function<void(uint32_t, const std::vector<float>*, void* userData)> cb = std::bind(
               &CrazyflieROS::on_logging_custom,
               this,
               std::placeholders::_1,
@@ -619,7 +619,7 @@ private:
     }
   }
 
-  void on_logging_custom(uint32_t time_in_ms, std::vector<double>* values, void* userData) {
+  void on_logging_custom(uint32_t time_in_ms, const std::vector<float>* values, void* userData) {
 
     auto pub = reinterpret_cast<rclcpp::Publisher<crazyflie_interfaces::msg::LogDataGeneric>::SharedPtr*>(userData);
 

--- a/crazyflie_interfaces/msg/LogDataGeneric.msg
+++ b/crazyflie_interfaces/msg/LogDataGeneric.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header  # Header including the ROS2 timestamp when the log data was received
 uint32 timestamp        # on-board timestamp from the STM32 (in ms)
-float64[] values        # converted values, in the order as specified for the log block
+float32[] values        # converted values, in the order as specified for the log block


### PR DESCRIPTION
To avoid memory overhead, since the crazyflie supports at most
32-bit floats.

Fixes #131