### PR TITLE
fixed remaining parameter slashes PR #159

### DIFF
--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -508,9 +508,9 @@ private:
     if (event.node == "/crazyflie_server") {
       auto params = param_subscriber_->get_parameters_from_event(event);
       for (auto &p : params) {
-        std::string prefix = name_ + "/params/";
+        std::string prefix = name_ + ".params.";
         if (p.get_name().find(prefix) == 0) {
-          size_t pos = p.get_name().find("/", prefix.size());
+          size_t pos = p.get_name().find(".", prefix.size());
           std::string group(p.get_name().begin() + prefix.size(), p.get_name().begin() + pos);
           std::string name(p.get_name().begin() + pos + 1, p.get_name().end());
 

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -222,7 +222,7 @@ public:
 
       // Update parameters
       for (const auto&i : set_param_map) {
-        std::string paramName = name + "/params/" + std::regex_replace(i.first, std::regex("\\."), "/");
+        std::string paramName = name + ".params." + std::regex_replace(i.first, std::regex("\\."), ".");
         auto result = node->set_parameter(rclcpp::Parameter(paramName, i.second));
         if (!result.successful) {
             RCLCPP_ERROR(logger_, "Could not set param %s (%s)", i.first.c_str(), result.reason.c_str());


### PR DESCRIPTION
Based on the issue mentioned in  discussion https://github.com/IMRCLab/crazyswarm2/discussions/162

There were some things we missed in this PR when we wanted to change the slashes to dots in parameter delimiters https://github.com/IMRCLab/crazyswarm2/pull/159