### PR TITLE
Broadcasts for setParam

### DIFF
--- a/crazyflie_examples/crazyflie_examples/set_param.py
+++ b/crazyflie_examples/crazyflie_examples/set_param.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+from crazyflie_py import *
+
+
+def main():
+    Z = 1.0
+    
+    swarm = Crazyswarm()
+    timeHelper = swarm.timeHelper
+    allcfs = swarm.allcfs
+
+    # disable LED (one by one)
+    for cf in allcfs.crazyflies:
+        cf.setParam("led.bitmask", 128)
+        timeHelper.sleep(1.0)
+
+    timeHelper.sleep(2.0)
+
+    # enable LED (broadcast)
+    allcfs.setParam("led.bitmask", 0)
+    timeHelper.sleep(5.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/crazyflie_examples/setup.cfg
+++ b/crazyflie_examples/setup.cfg
@@ -4,3 +4,4 @@ console_scripts =
     nice_hover = crazyflie_examples.nice_hover:main
     figure8 = crazyflie_examples.figure8:main
     cmd_full_state = crazyflie_examples.cmd_full_state:main
+    set_param = crazyflie_examples.set_param:main


### PR DESCRIPTION
Using all.param.<name>.<group> can be used to update a parameter on all
Crazyflies via broadcast.
This is useful if the parameter change should take effect at the same
time.