### PR TITLE
Added multiagent simulation fix for new crazyflie-firmware

### DIFF
--- a/crazyflie_sim/crazyflie_sim/crazyflie_sil.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_sil.py
@@ -81,7 +81,6 @@ class CrazyflieSIL:
         self.motors_thrust_uncapped = firm.motors_thrust_uncapped_t()
         self.motors_thrust_pwm = firm.motors_thrust_pwm_t()
 
-        self.mellinger_control = firm.controllerMellinger_t()
         self.controller_name = controller_name
 
         # set up controller
@@ -91,6 +90,7 @@ class CrazyflieSIL:
             firm.controllerPidInit()
             self.controller = firm.controllerPid
         elif controller_name == "mellinger":
+            self.mellinger_control = firm.controllerMellinger_t()
             firm.controllerMellingerInit(self.mellinger_control)
             self.controller = firm.controllerMellinger
         elif controller_name == "brescianini":

--- a/crazyflie_sim/crazyflie_sim/crazyflie_sil.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_sil.py
@@ -81,6 +81,9 @@ class CrazyflieSIL:
         self.motors_thrust_uncapped = firm.motors_thrust_uncapped_t()
         self.motors_thrust_pwm = firm.motors_thrust_pwm_t()
 
+        self.mellinger_control = firm.controllerMellinger_t()
+        self.controller_name = controller_name
+
         # set up controller
         if controller_name == "none":
             self.controller = None
@@ -88,7 +91,7 @@ class CrazyflieSIL:
             firm.controllerPidInit()
             self.controller = firm.controllerPid
         elif controller_name == "mellinger":
-            firm.controllerMellingerInit()
+            firm.controllerMellingerInit(self.mellinger_control)
             self.controller = firm.controllerMellinger
         elif controller_name == "brescianini":
             firm.controllerBrescianiniInit()
@@ -265,7 +268,10 @@ class CrazyflieSIL:
         time_in_seconds = self.time_func()
         # ticks is essentially the time in milliseconds as an integer
         tick = int(time_in_seconds * 1000)
-        self.controller(self.control, self.setpoint, self.sensors, self.state, tick)
+        if self.controller_name != "mellinger":
+            self.controller(self.control, self.setpoint, self.sensors, self.state, tick)
+        else:
+            self.controller(self.mellinger_control, self.control, self.setpoint, self.sensors, self.state, tick)
         return self._fwcontrol_to_sim_data_types_action()
 
     # "private" methods


### PR DESCRIPTION
Hi @knmcguire, @whoenig added a firmware update https://github.com/bitcraze/crazyflie-firmware/commit/368c174db998bff58a4c707fd9c1a06ced45728a however by it is not compatible with the current version of crazyswarm2, hence this is a little fix, to call the controller, and it solves the bug for multiagent behavior previously. By changing to other controllers it will not affect the `executeController` too
![crazywarm](https://user-images.githubusercontent.com/64059887/212553893-6b20c942-7777-4f19-be90-1c026894fe3a.gif)
