### PR TITLE
Update installation.rst

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -69,7 +69,9 @@ First Installation
 
     .. code-block:: bash
 
-        export PYTHONPATH=<replace-with-path-to>/crazyflie-firmware:$PYTHONPATH
+        export PYTHONPATH=<replace-with-path-to>/crazyflie-firmware/build:$PYTHONPATH
+        
+   If you are working from an older version of the crazyflie-firmware (before tag 2023.02), then you will need to point to main folder of the repo (so remove the '/build' part. 
 
 
 Updating


### PR DESCRIPTION
The crazyflie firmware python bindings have been moved to the build folder after this PR: https://github.com/bitcraze/crazyflie-firmware/pull/1184

These adds instructions to the doc to update that and warn users if they are using an earlier version of the CF firmware repo.


This issue was noted by https://github.com/IMRCLab/crazyswarm2/discussions/196#discussioncomment-5086207