### PR TITLE
change all ROS2 to ROS 2 with space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![ROS2](https://github.com/IMRCLab/crazyswarm2/actions/workflows/ci-ros2.yml/badge.svg)](https://github.com/IMRCLab/crazyswarm2/actions/workflows/ci-ros2.yml)
+[![ROS 2](https://github.com/IMRCLab/crazyswarm2/actions/workflows/ci-ros2.yml/badge.svg)](https://github.com/IMRCLab/crazyswarm2/actions/workflows/ci-ros2.yml)
 
 # Crazyswarm2
-A ROS2-based stack for Bitcraze Crazyflie multirotor robots.
+A ROS 2-based stack for Bitcraze Crazyflie multirotor robots.
 
 The documentation is available here: https://imrclab.github.io/crazyswarm2/.
 

--- a/crazyflie/package.xml
+++ b/crazyflie/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>crazyflie</name>
   <version>2.0.0</version>
-  <description>ROS2 Package for Bitcraze Crazyflie robots</description>
+  <description>ROS 2 Package for Bitcraze Crazyflie robots</description>
   <maintainer email="hoenig@tu-berlin.de">Wolfgang Hönig, Kimberly McGuire</maintainer>
   <license>MIT</license>
 

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -142,7 +142,7 @@ class CrazyflieServer(Node):
 
             self.swarm._cfs[link_uri].logging["enabled"] = logging_enabled
 
-            # check if predefine log blocks can be logged and setup crazyflie logblocks and ROS2 publishers
+            # check if predefine log blocks can be logged and setup crazyflie logblocks and ROS 2 publishers
             for default_log_name in self.default_log_type:
                 prefix = default_log_name
                 topic_type = self.default_log_type[default_log_name]
@@ -175,7 +175,7 @@ class CrazyflieServer(Node):
             self.swarm._cfs[link_uri].logging["custom_log_groups"] = {}
             self.swarm._cfs[link_uri].logging["custom_log_publisher"] = {}
 
-            # Setup log blocks for each custom log and ROS2 publisher topics
+            # Setup log blocks for each custom log and ROS 2 publisher topics
             if custom_logging_enabled:
                 for log_group_name in custom_log_topics:
                     frequency = custom_log_topics[log_group_name]["frequency"]
@@ -290,7 +290,7 @@ class CrazyflieServer(Node):
 
     def _param_to_dict(self, param_ros):
         """
-        Turn ROS2 parameters from the node into a dict
+        Turn ROS 2 parameters from the node into a dict
         """
         tree = {}
         for item in param_ros:
@@ -329,7 +329,7 @@ class CrazyflieServer(Node):
     def _init_logging(self):
         """
         Sets up all the log blocks for the crazyflie and
-           all the ROS2 publisher and parameters for logging
+           all the ROS 2 publisher and parameters for logging
            at startup
         """
         for link_uri in self.uris:
@@ -376,7 +376,7 @@ class CrazyflieServer(Node):
 
     def _init_default_logging(self, prefix, link_uri, callback_fnc):
         """
-        Sets up all the default log blocks and ROS2 publishers for the crazyflie
+        Sets up all the default log blocks and ROS 2 publishers for the crazyflie
         """
         cf_handle = self.swarm._cfs[link_uri]
         cf = cf_handle.cf
@@ -402,7 +402,7 @@ class CrazyflieServer(Node):
     def _log_scan_data_callback(self, timestamp, data, logconf, uri):
         """
         Once multiranger range is retrieved from the Crazyflie, 
-            send out the ROS2 topic for Scan
+            send out the ROS 2 topic for Scan
         """
         cf_name = self.cf_dict[uri]
         max_range = 3.49
@@ -434,7 +434,7 @@ class CrazyflieServer(Node):
     def _log_pose_data_callback(self, timestamp, data, logconf, uri):
         """
         Once pose data is retrieved from the Crazyflie, 
-            send out the ROS2 topic for Pose
+            send out the ROS 2 topic for Pose
         """
 
         cf_name = self.cf_dict[uri]
@@ -475,7 +475,7 @@ class CrazyflieServer(Node):
     def _log_odom_data_callback(self, timestamp, data, logconf, uri):
         """
         Once pose and velocity data is retrieved from the Crazyflie, 
-            send out the ROS2 topic for Odometry in 2D (no z-axis)
+            send out the ROS 2 topic for Odometry in 2D (no z-axis)
         """
         cf_name = self.cf_dict[uri]
 
@@ -529,7 +529,7 @@ class CrazyflieServer(Node):
     def _log_custom_data_callback(self, timestamp, data, logconf, uri):
         """
         Once custom log block is retrieved from the Crazyflie, 
-            send out the ROS2 topic for that same type of log
+            send out the ROS 2 topic for that same type of log
         """
         msg = LogDataGeneric()
         msg.header.stamp = self.get_clock().now().to_msg()
@@ -546,7 +546,7 @@ class CrazyflieServer(Node):
     def _init_parameters(self):
         """
         Once custom log block is retrieved from the Crazyflie, 
-            send out the ROS2 topic for that same type of log
+            send out the ROS 2 topic for that same type of log
         """
         for link_uri in self.uris:
             cf = self.swarm._cfs[link_uri].cf
@@ -581,7 +581,7 @@ class CrazyflieServer(Node):
 
                     if set_param_value is not None:
                         # If value is found in initial parameters,
-                        # set crazyflie firmware value and declare value in ROS2 parameter
+                        # set crazyflie firmware value and declare value in ROS 2 parameter
                         # Note: currently this is not possible to get the most recent from the
                         #       crazyflie with get_value due to threading.
                         cf.param.set_value(name, set_param_value)
@@ -596,7 +596,7 @@ class CrazyflieServer(Node):
                         )
                     else:
                         # If value is not found in initial parameter set
-                        # get crazyflie paramter value and declare that value in ROS2 parameter
+                        # get crazyflie paramter value and declare that value in ROS 2 parameter
 
                         if cf_log_to_ros_param[type_cf_param] is ParameterType.PARAMETER_INTEGER:
                             cf_param_value = int(cf.param.get_value(name))
@@ -615,7 +615,7 @@ class CrazyflieServer(Node):
     def _parameters_callback(self, params):
         """
         Sets up all the parameters for the crazyflie and
-           translates it to ROS2 paraemeters at startup
+           translates it to ROS 2 paraemeters at startup
         """
         for param in params:
             param_split = param.name.split(".")

--- a/crazyflie_interfaces/msg/LogDataGeneric.msg
+++ b/crazyflie_interfaces/msg/LogDataGeneric.msg
@@ -1,3 +1,3 @@
-std_msgs/Header header  # Header including the ROS2 timestamp when the log data was received
+std_msgs/Header header  # Header including the ROS 2 timestamp when the log data was received
 uint32 timestamp        # on-board timestamp from the STM32 (in ms)
 float32[] values        # converted values, in the order as specified for the log block

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -63,7 +63,7 @@ class TimeHelper:
 
     def sleepForRate(self, rateHz):
         """Sleeps so that, if called in a loop, executes at specified rate."""
-        # Note: The following ROS2 construct cannot easily be used, because in ROS2
+        # Note: The following ROS 2 construct cannot easily be used, because in ROS 2
         #       there is no implicit threading anymore. Thus, the rosRate.sleep() call
         #       is blocking. Instead, we simulate the rate behavior ourselves.
         # if self.rosRate is None or self.rateHz != rateHz:

--- a/crazyflie_sim/crazyflie_sim/crazyflie_server.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_server.py
@@ -161,7 +161,7 @@ class CrazyflieServer(Node):
 
     def _param_to_dict(self, param_ros):
         """
-        Turn ROS2 parameters from the node into a dict
+        Turn ROS 2 parameters from the node into a dict
         """
         tree = {}
         for item in param_ros:

--- a/crazyflie_sim/crazyflie_sim/visualization/rviz.py
+++ b/crazyflie_sim/crazyflie_sim/visualization/rviz.py
@@ -7,7 +7,7 @@ from ..sim_data_types import State, Action
 
 
 class Visualization:
-    """Publishes ROS2 transforms of the states, so that they can be visualized in RVIZ"""
+    """Publishes ROS 2 transforms of the states, so that they can be visualized in RVIZ"""
 
     def __init__(self, node: Node, params: dict, names: list[str], states: list[State]):
         self.node = node

--- a/docs2/faq.rst
+++ b/docs2/faq.rst
@@ -30,7 +30,7 @@ Crazyswarm2 was forked from Crazyswarm. However, there is also heavy re-design o
 - **Motion capture integration.**
   In Crazyswarm1, the motion capture integration is part of the crazyswarm_server, due to limitations in the ROS1 pub/sub system.
   In contrast, Crazyswarm2 now follows a better ROS-style design, where our motion capture abstraction layer and custom
-  frame-by-frame tracking is available as a `separate ROS2 package <https://github.com/IMRCLab/motion_capture_tracking>`_.
+  frame-by-frame tracking is available as a `separate ROS 2 package <https://github.com/IMRCLab/motion_capture_tracking>`_.
   In addition, Crazyswarm2 is designed to support other localization methods (lighthouse, or on-board only localization) from the start.
 
 - **Communication backend.**
@@ -57,7 +57,7 @@ Both can be used to control several Crazyflies from a Python script.
 Here are some differences:
 
 - **Motion capture integration.**
-  Crazyswarm2 supports common motion capture systems using the ROS2 package `motion_capture_tracking <https://github.com/IMRCLab/motion_capture_tracking/tree/ros2>`_.
+  Crazyswarm2 supports common motion capture systems using the ROS 2 package `motion_capture_tracking <https://github.com/IMRCLab/motion_capture_tracking/tree/ROS 2>`_.
   The Bitcraze API can *send* position measurements to the Crazyflie,
   but does not know how to *get* position measurements from mocap hardware.
   Moreover, the use of motion_capture_tracking allows to use identical or single motion capture markers.
@@ -71,6 +71,6 @@ Here are some differences:
   for certain modules in the Crazyflie firmware.
   The binding system can be helpful when developing new firmware modules,
   especially when they are mathematically complex and hard to debug.
-- **ROS2 foundation.**
-  The Crazyswarm2 server program is a ROS2 node.
-  Our Python API is a thin wrapper around the ROS2 interface.
+- **ROS 2 foundation.**
+  The Crazyswarm2 server program is a ROS 2 node.
+  Our Python API is a thin wrapper around the ROS 2 interface.

--- a/docs2/index.rst
+++ b/docs2/index.rst
@@ -1,9 +1,9 @@
 .. _introduction:
 
-Crazyswarm2: A ROS2 testbed for Aerial Robot Teams
+Crazyswarm2: A ROS 2 testbed for Aerial Robot Teams
 ==================================================
 
-Crazyswarm2 is a **work-in-progress** port of the original `Crazyswarm <https://crazyswarm.readthedocs.io>`_ to ROS2.
+Crazyswarm2 is a **work-in-progress** port of the original `Crazyswarm <https://crazyswarm.readthedocs.io>`_ to ROS 2.
 It is fully open-source and available on `github <https://github.com/IMRCLab/crazyswarm2>`_.
 
 Crazyswarm2 is primarily made for researchers that want to operate or simulate a team of unmanned aerial vehicles (UAVs) that uses the

--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -6,7 +6,7 @@ Installation
 Crazyswarm2 runs on **Ubuntu Linux** in one of the following configurations:
 
 ====== ======== ========
-Ubuntu Python   ROS2
+Ubuntu Python   ROS 2
 ------ -------- --------
 20.04  3.7, 3.8 Galactic
 22.04  3.10     Humble
@@ -22,7 +22,7 @@ Ubuntu Python   ROS2
 First Installation
 ------------------
 
-1. If needed, install ROS2 using the instructions at https://docs.ros.org/en/galactic/Installation.html or https://docs.ros.org/en/humble/Installation.html.
+1. If needed, install ROS 2 using the instructions at https://docs.ros.org/en/galactic/Installation.html or https://docs.ros.org/en/humble/Installation.html.
 
 2. Install dependencies
 
@@ -38,7 +38,7 @@ First Installation
         pip3 install cflib transforms3d
         sudo apt-get install ros-*DISTRO*-tf-transformations
 
-3. Set up your ROS2 workspace
+3. Set up your ROS 2 workspace
 
     .. code-block:: bash
 
@@ -47,7 +47,7 @@ First Installation
         git clone https://github.com/IMRCLab/crazyswarm2 --recursive
         git clone --branch ros2 --recursive https://github.com/IMRCLab/motion_capture_tracking.git
 
-4. Build your ROS2 workspace
+4. Build your ROS 2 workspace
 
     .. code-block:: bash
 
@@ -59,7 +59,7 @@ First Installation
 
 5. Set up software-in-the-loop simulation (optional)
 
-    This currently requires cloning the Crazyflie firmware and building the Python bindings manually. In a separate folder (not part of your ROS2 workspace!), 
+    This currently requires cloning the Crazyflie firmware and building the Python bindings manually. In a separate folder (not part of your ROS 2 workspace!), 
 
     .. code-block:: bash
 

--- a/docs2/overview.rst
+++ b/docs2/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-This page will explain the overview of the crazyflie ROS2 nodes:
+This page will explain the overview of the crazyflie ROS 2 nodes:
 
 .. image:: images/overview_nodes.jpg
 
@@ -11,13 +11,13 @@ This page will explain the overview of the crazyflie ROS2 nodes:
 Explanation per node
 --------------------
 
-In the `source code of the Crazyswarm2 (Crazyflie ROS2) project <https://github.com/IMRCLab/crazyswarm2>`_, there are several packages that we will explain here:
+In the `source code of the Crazyswarm2 (Crazyflie ROS 2) project <https://github.com/IMRCLab/crazyswarm2>`_, there are several packages that we will explain here:
 
 
 - **crazyflie/**: The package that contains the crazyflie server nodes and the crazyflies.yaml.
-- **crazyflie_py/**: The package that contains the python library that wraps around the ROS2 services and topics that connects with the crazyflie server nodes.
-- **crazyflie_examples/**:  The package that contains examples of using the crazyflie ros2 package. See :ref:`tutorials`.
-- **crazyflie_interfaces/**: The package that contain all msgs and srvs for the crazyflie ROS2 project.
+- **crazyflie_py/**: The package that contains the python library that wraps around the ROS 2 services and topics that connects with the crazyflie server nodes.
+- **crazyflie_examples/**:  The package that contains examples of using the crazyflie ROS 2 package. See :ref:`tutorials`.
+- **crazyflie_interfaces/**: The package that contain all msgs and srvs for the crazyflie ROS 2 project.
 
 Crazyflie server
 ----------------
@@ -31,8 +31,8 @@ It has two backends that you can choose from:
 
 It handles several low level communication aspects with the Crazyflies:
 
-- **Parameter to ROS2 parameters handling**: It receives the parameter ToC from the Crazyflie, transforms it into ROS2 parameters, and sets the CF2 parameters based on the *crazyflies.yaml* input.
-- **Logging to ROS2 topics handling**: The server sets up logblocks for data streaming in the crazyflie, and transforms the received variables into ROS2 topics.
+- **Parameter to ROS 2 parameters handling**: It receives the parameter ToC from the Crazyflie, transforms it into ROS 2 parameters, and sets the CF2 parameters based on the *crazyflies.yaml* input.
+- **Logging to ROS 2 topics handling**: The server sets up logblocks for data streaming in the crazyflie, and transforms the received variables into ROS 2 topics.
 - **Run-time configuration**: Both parameters and logging can be configured in run-time while the server is connected with the Crazyflies. Please check :ref:`usage`.
 
 It also setups several flight command services:

--- a/docs2/tutorials.rst
+++ b/docs2/tutorials.rst
@@ -1,6 +1,6 @@
 .. _tutorials:
 
-ROS2 Tutorials
+ROS 2 Tutorials
 ==============
 
 This page shows tutorials which connects the Crazyflie through Crazyswarm2 to with external packages like RVIZ2, teleop_twist_keyboard, SLAM toolbox and NAV2 bringup. Have fun!
@@ -84,7 +84,7 @@ Here you can see an example of 5 crazyflies with the Pose default topic enabled,
 Mapping with the SLAM toolbox
 -----------------------------
 
-You can connect the Crazyflie through ROS2 with existing packages like the `SLAM toolbox <https://github.com/SteveMacenski/slam_toolbox/>`_. 
+You can connect the Crazyflie through ROS 2 with existing packages like the `SLAM toolbox <https://github.com/SteveMacenski/slam_toolbox/>`_. 
 With a `Flow deck <https://www.bitcraze.io/products/flow-deck-v2/>`_ and `Multi-ranger <https://www.bitcraze.io/products/multi-ranger-deck/>`_
 ) a simple map can be created.
 
@@ -94,7 +94,7 @@ With a `Flow deck <https://www.bitcraze.io/products/flow-deck-v2/>`_ and `Multi-
 Preperation
 ~~~~~~~~~~~
 
-Assuming you have installed ROS2 and Crazyswarm2 according to the instructions and went through the guides on Usage, now install the slam toolbox:
+Assuming you have installed ROS 2 and Crazyswarm2 according to the instructions and went through the guides on Usage, now install the slam toolbox:
 
 .. code-block:: bash
 
@@ -361,7 +361,7 @@ The next two nodes are new, which are included IncludeLaunchDescription to inclu
 Navigate the Crazyflie
 ~~~~~~~~~~~~~~~~~~~~~~
 
-In a terminal run the following from the ros2 workspace. 
+In a terminal run the following from the ROS 2 workspace. 
 
 .. code-block:: bash
 

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -4,7 +4,7 @@ Usage
 =====
 
 .. warning::
-    Do not forget to source your ROS2 workspace in each terminal you would like to use it
+    Do not forget to source your ROS 2 workspace in each terminal you would like to use it
 
     .. code-block:: bash
 
@@ -130,7 +130,7 @@ Example:
 Physical Experiments
 --------------------
 
-ROS2 terminal
+ROS 2 terminal
 ~~~~~~~~~~~~~
 
 The following shows a simple take off and land example without any launch files or yaml files
@@ -165,7 +165,7 @@ In another terminal after sourcing the right setup.bash files, run:
     ros2 service call /cf2/add_logging crazyflie_interfaces/srv/AddLogging "{topic_name: 'topic_test', frequency: 10, vars: ['stateEstimate.x','stateEstimate.y','stateEstimate.z']}"
     ros2 service call /cf2/add_logging crazyflie_interfaces/srv/AddLogging "{topic_name: 'pose', frequency: 10}
 
-With ROS2's rqt you can look at the topics, or with 'ROS2 topics echo /cf2/pose'
+With ROS 2's rqt you can look at the topics, or with 'ROS 2 topics echo /cf2/pose'
 
 To close the logblocks again, run:
 


### PR DESCRIPTION
So [this tweet](https://twitter.com/OpenRoboticsOrg/status/1628514177009713155?s=20) mentioned the wrong use of ROS 2 and we use ROS2 everywhere in our doc. 

This PR should fix that