### PR TITLE
server(cpp): disable query of parameter values by default

### DIFF
--- a/crazyflie/config/server.yaml
+++ b/crazyflie/config/server.yaml
@@ -1,5 +1,7 @@
 /crazyflie_server:
   ros__parameters:
+    firmware_params:
+      query_all_values_on_connect: False
     # simulation related
     sim:
       max_dt: 0 #0.1              # artificially limit the step() function (set to 0 to disable)

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -160,34 +160,64 @@ public:
     };
 
     if (enable_parameters) {
+      bool query_all_values_on_connect = node->get_parameter("firmware_params.query_all_values_on_connect").get_parameter_value().get<bool>();
+
       int numParams = 0;
       RCLCPP_INFO(logger_, "Requesting parameters...");
-      cf_.requestParamToc(/*forceNoCache*/);
+      cf_.requestParamToc(/*forceNoCache*/false, /*requestValues*/query_all_values_on_connect);
       for (auto iter = cf_.paramsBegin(); iter != cf_.paramsEnd(); ++iter) {
         auto entry = *iter;
         std::string paramName = name + ".params." + entry.group + "." + entry.name;
         switch (entry.type)
         {
         case Crazyflie::ParamTypeUint8:
-          node->declare_parameter(paramName, cf_.getParam<uint8_t>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter(paramName, cf_.getParam<uint8_t>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_INTEGER);
+          }
           break;
         case Crazyflie::ParamTypeInt8:
-          node->declare_parameter(paramName, cf_.getParam<int8_t>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter(paramName, cf_.getParam<int8_t>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_INTEGER);
+          }
           break;
         case Crazyflie::ParamTypeUint16:
-          node->declare_parameter(paramName, cf_.getParam<uint16_t>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter(paramName, cf_.getParam<uint16_t>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_INTEGER);
+          }
           break;
         case Crazyflie::ParamTypeInt16:
-          node->declare_parameter(paramName, cf_.getParam<int16_t>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter(paramName, cf_.getParam<int16_t>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_INTEGER);
+          }
           break;
         case Crazyflie::ParamTypeUint32:
-          node->declare_parameter<int64_t>(paramName, cf_.getParam<uint32_t>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter<int64_t>(paramName, cf_.getParam<uint32_t>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_INTEGER);
+          }
           break;
         case Crazyflie::ParamTypeInt32:
-          node->declare_parameter(paramName, cf_.getParam<int32_t>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter(paramName, cf_.getParam<int32_t>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_INTEGER);
+          }
           break;
         case Crazyflie::ParamTypeFloat:
-          node->declare_parameter(paramName, cf_.getParam<float>(entry.id));
+          if (query_all_values_on_connect) {
+            node->declare_parameter(paramName, cf_.getParam<float>(entry.id));
+          } else {
+            node->declare_parameter(paramName, rclcpp::PARAMETER_DOUBLE);
+          }
           break;
         default:
           RCLCPP_WARN(logger_, "Unknown param type for %s/%s", entry.group.c_str(), entry.name.c_str());
@@ -389,7 +419,12 @@ public:
         cf_.setParam<int32_t>(entry->id, p.as_int());
         break;
       case Crazyflie::ParamTypeFloat:
-        cf_.setParam<float>(entry->id, p.as_double());
+        if (p.get_type() == rclcpp::PARAMETER_INTEGER) {
+          cf_.setParam<float>(entry->id, (float)p.as_int());
+        } else {
+          cf_.setParam<float>(entry->id, p.as_double());
+        }
+
         break;
       }
     } else {
@@ -683,9 +718,10 @@ public:
     service_go_to_ = this->create_service<GoTo>("all/go_to", std::bind(&CrazyflieServer::go_to, this, _1, _2));
     service_notify_setpoints_stop_ = this->create_service<NotifySetpointsStop>("all/notify_setpoints_stop", std::bind(&CrazyflieServer::notify_setpoints_stop, this, _1, _2));
 
-       // declare global commands
+    // declare global params
     this->declare_parameter("all.broadcasts.num_repeats", 15);
     this->declare_parameter("all.broadcasts.delay_between_repeats_ms", 1);
+    this->declare_parameter("firmware_params.query_all_values_on_connect", false);
 
     broadcasts_num_repeats_ = this->get_parameter("all.broadcasts.num_repeats").get_parameter_value().get<int>();
     broadcasts_delay_between_repeats_ms_ = this->get_parameter("all.broadcasts.delay_between_repeats_ms").get_parameter_value().get<int>();
@@ -972,7 +1008,11 @@ private:
                 broadcast_set_param<int32_t>(group, name, p.as_int());
                 break;
               case Crazyflie::ParamTypeFloat:
-                broadcast_set_param<float>(group, name, p.as_double());
+                if (p.get_type() == rclcpp::PARAMETER_INTEGER) {
+                  broadcast_set_param<float>(group, name, (float)p.as_int());
+                } else {
+                  broadcast_set_param<float>(group, name, p.as_double());
+                }
                 break;
               }
               break;

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -18,7 +18,7 @@ import rclpy.node
 import rowan
 from std_srvs.srv import Empty
 from geometry_msgs.msg import Point, Twist
-from rcl_interfaces.srv import GetParameters, SetParameters, ListParameters, GetParameterTypes
+from rcl_interfaces.srv import GetParameters, SetParameters, ListParameters, DescribeParameters
 from rcl_interfaces.msg import Parameter, ParameterValue, ParameterType
 from crazyflie_interfaces.srv import Takeoff, Land, GoTo, UploadTrajectory, StartTrajectory, NotifySetpointsStop
 from crazyflie_interfaces.msg import TrajectoryPolynomialPiece, FullState, Position
@@ -88,7 +88,7 @@ class Crazyflie:
     The bulk of the module's functionality is contained in this class.
     """
 
-    def __init__(self, node, cfname):
+    def __init__(self, node, cfname, paramTypeDict):
         """Constructor.
 
         Args:
@@ -125,7 +125,6 @@ class Crazyflie:
         req = GetParameters.Request()
         req.names = ["robots.{}.initial_position".format(cfname), "robots.{}.uri".format(cfname)]
         future = getParamsService.call_async(req)
-        params = []
         while rclpy.ok():
             rclpy.spin_once(node)
             if future.done():
@@ -143,43 +142,7 @@ class Crazyflie:
 
                 break
 
-        # Query all parameters
-        listParamsService = node.create_client(ListParameters, "/crazyflie_server/list_parameters")
-        listParamsService.wait_for_service()
-        req = ListParameters.Request()
-        req.depth = ListParameters.Request.DEPTH_RECURSIVE
-        req.prefixes = []
-        future = listParamsService.call_async(req)
-        params = []
-        while rclpy.ok():
-            rclpy.spin_once(node)
-            if future.done():
-                # Filter the parameters that belong to this Crazyflie
-                response = future.result()
-                for p in response.result.names:
-                    param_prefix = "{}.params.".format(prefix[1:])
-                    if p.startswith(param_prefix):
-                        # params.append(p[len(param_prefix):])
-                        params.append(p)
-                break
-
-        # Find the types for the parameters and store them
-        getParamTypesService = node.create_client(GetParameterTypes, "/crazyflie_server/get_parameter_types")
-        getParamTypesService.wait_for_service()
-        req = GetParameterTypes.Request()
-        req.names = params
-        future = getParamTypesService.call_async(req)
-        self.paramTypeDict = dict()
-        while rclpy.ok():
-            rclpy.spin_once(node)
-            if future.done():
-                # Filter the parameters that belong to this Crazyflie
-                response = future.result()
-                for p, t in zip(params, response.types):
-                    self.paramTypeDict[p[len(param_prefix):]] = t
-                break
-
-        # print(params)
+        self.paramTypeDict = paramTypeDict
 
         self.cmdFullStatePublisher = node.create_publisher(FullState, prefix + "/cmd_full_state", 1)
         self.cmdFullStateMsg = FullState()
@@ -695,11 +658,53 @@ class CrazyflieServer(rclpy.node.Node):
                 if cfname != "all":
                     cfnames.append(cfname)
 
+        # Query all parameters
+        listParamsService = self.create_client(ListParameters, "/crazyflie_server/list_parameters")
+        listParamsService.wait_for_service()
+        req = ListParameters.Request()
+        req.depth = ListParameters.Request.DEPTH_RECURSIVE
+        req.prefixes = []
+        future = listParamsService.call_async(req)
+        params = []
+        while rclpy.ok():
+            rclpy.spin_once(self)
+            if future.done():
+                # Filter the parameters that belong to this Crazyflie
+                response = future.result()
+                for p in response.result.names:
+                    if ".params." in p:
+                        params.append(p)
+                break
+
+        # Find the types for the parameters and store them
+        describeParametersService = self.create_client(DescribeParameters, "/crazyflie_server/describe_parameters")
+        describeParametersService.wait_for_service()
+        req = DescribeParameters.Request()
+        req.names = params
+        future = describeParametersService.call_async(req)
+        allParamTypeDicts = dict()
+        while rclpy.ok():
+            rclpy.spin_once(self)
+            if future.done():
+                # Filter the parameters that belong to this Crazyflie
+                response = future.result()
+                for p, d in zip(params, response.descriptors):
+                    idx = p.index(".params.")
+                    cf_name = p[0:idx]
+                    param_name = p[idx+8:]
+                    t = d.type
+                    if cf_name in allParamTypeDicts:
+                        allParamTypeDicts[cf_name][param_name] = t
+                    else:
+                        allParamTypeDicts[cf_name] = {param_name: t}
+                break
+        self.paramTypeDict = allParamTypeDicts["all"]
+
         self.crazyflies = []
         self.crazyfliesById = dict()
         self.crazyfliesByName = dict()
         for cfname in cfnames:
-            cf = Crazyflie(self, cfname)
+            cf = Crazyflie(self, cfname, allParamTypeDicts[cfname])
             self.crazyflies.append(cf)
             self.crazyfliesByName[cfname] = cf
             # For legacy crazyswarm1 code, also provide crazyfliesById
@@ -815,14 +820,7 @@ class CrazyflieServer(rclpy.node.Node):
     def setParam(self, name, value):
         """Broadcasted setParam. See Crazyflie.setParam() for details."""
         param_name = "all.params." + name
-        param_type = None
-        for cf in self.crazyflies:
-            if name in cf.paramTypeDict:
-                param_type = cf.paramTypeDict[name]
-                break
-        if param_type is None:
-            self.node.get_logger().error("Unknown param type!")
-            return
+        param_type = self.paramTypeDict[name]
         if param_type == ParameterType.PARAMETER_INTEGER:
             param_value = ParameterValue(type=param_type, integer_value=int(value))
         elif param_type == ParameterType.PARAMETER_DOUBLE:


### PR DESCRIPTION
Querying all 200+ parameters increases the connection time significantly. At the same time, the actual values are often not needed. Here, we disable the query by default, but the user can get the old behavior by changing a (global) setting. In the future, it might be useful to have a service call to update a list of given parameters (e.g., to query of some deck was initialized).