### PR TITLE
Add warnings for motion capture issues

### DIFF
--- a/crazyflie/config/server.yaml
+++ b/crazyflie/config/server.yaml
@@ -1,5 +1,9 @@
 /crazyflie_server:
   ros__parameters:
+    warnings:
+      frequency: 1.0 # report/run checks once per second
+      motion_capture:
+        warning_if_rate_outside: [80.0, 120.0]
     # simulation related
     sim:
       max_dt: 0 #0.1              # artificially limit the step() function (set to 0 to disable)

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -754,8 +754,8 @@ public:
     if (freq >= 0.0) {
       watchdog_timer_ = this->create_wall_timer(std::chrono::milliseconds((int)(1000.0/freq)), std::bind(&CrazyflieServer::on_watchdog_timer, this));
     }
-    this->declare_parameter("warnings.motion_capture.warning_if_rate_outside", std::vector<float>({80.0, 120.0}));
-    auto rate_range = this->get_parameter("warnings.motion_capture.warning_if_rate_outside").get_parameter_value().get<std::vector<float>>();
+    this->declare_parameter("warnings.motion_capture.warning_if_rate_outside", std::vector<double>({80.0, 120.0}));
+    auto rate_range = this->get_parameter("warnings.motion_capture.warning_if_rate_outside").get_parameter_value().get<std::vector<double>>();
     mocap_min_rate_ = rate_range[0];
     mocap_max_rate_ = rate_range[1];
   }


### PR DESCRIPTION
* Warn if no motion capture information is received, even though this was enabled (#30)
* Warn if motion capture rate is out of an expected range (#32)

This also adds a watchdog infrastructure to be used to periodically monitor/report issues. This might be useful for #209 in the future.