### PR TITLE
fix yaw conversion from quat in cmd_full_state in crazyflie_sim/crazyflie_server

### DIFF
--- a/crazyflie_sim/crazyflie_sim/crazyflie_server.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_server.py
@@ -326,7 +326,7 @@ class CrazyflieServer(Node):
              msg.pose.orientation.x,
              msg.pose.orientation.y,
              msg.pose.orientation.z]
-        rpy = rowan.to_euler(q)
+        rpy = rowan.to_euler(q, convention='xyz')
 
         self.cfs[name].cmdFullState(
             [msg.pose.position.x, msg.pose.position.y, msg.pose.position.z],


### PR DESCRIPTION
There is an issue in yaw control in simulation via cmd_full_state. The yaw is always zero since the convention in `rowan.to_euler()` is 'zyx'. 

Fix it by modify the convention in 'xyz'.