### PR TITLE
fix quaternion integration equation in backend np

### DIFF
--- a/crazyflie_sim/crazyflie_sim/backend/np.py
+++ b/crazyflie_sim/crazyflie_sim/backend/np.py
@@ -110,7 +110,7 @@ class Quadrotor:
         # to integrate the dynamics, see
         # https://www.ashwinnarayan.com/post/how-to-integrate-quaternions/, and
         # https://arxiv.org/pdf/1604.08139.pdf
-        # 
+        # Sec 4.5, https://arxiv.org/pdf/1711.02508.pdf
         omega_global = rowan.rotate(self.state.quat, self.state.omega)
         q_next = rowan.normalize(
             rowan.calculus.integrate(

--- a/crazyflie_sim/crazyflie_sim/backend/np.py
+++ b/crazyflie_sim/crazyflie_sim/backend/np.py
@@ -110,9 +110,11 @@ class Quadrotor:
         # to integrate the dynamics, see
         # https://www.ashwinnarayan.com/post/how-to-integrate-quaternions/, and
         # https://arxiv.org/pdf/1604.08139.pdf
+        # 
+        omega_global = rowan.rotate(self.state.quat, self.state.omega)
         q_next = rowan.normalize(
             rowan.calculus.integrate(
-                self.state.quat, self.state.omega, dt))
+                self.state.quat, omega_global, dt))
 
         # mJ = Jw x w + tau_u
         omega_next = self.state.omega + (


### PR DESCRIPTION
Issue: when using backend=np, change yaw (nonzero) and position will make the attitude instable.

Reason: this is caused by incorrect quaternion integration equation: 
`rowan.calculus.integrate(self.state.quat, self.state.omega, dt)`, 
which is defined for quaternion integration equation using global angular velocity, see [Eq. 194](https://arxiv.org/pdf/1711.02508.pdf). However, `self.state.omega` is defined in local frame.

Solution: to fix the issue, the local angular rate `self.state.omega` needs to be converted into the global frame using `rowan.rotate`, see [Eq. 204](https://arxiv.org/pdf/1711.02508.pdf).

 