### PR TITLE
Fix frequent crashes of figure8 example

### DIFF
--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -389,7 +389,11 @@ class Crazyflie:
         req.trajectory_id = trajectoryId
         req.piece_offset = pieceOffset
         req.pieces = pieces
-        self.uploadTrajectoryService.call_async(req)
+        future = self.uploadTrajectoryService.call_async(req)
+        while rclpy.ok():
+            rclpy.spin_once(self.node)
+            if future.done():
+                break
 
     def startTrajectory(self, trajectoryId,
                         timescale=1.0, reverse=False,


### PR DESCRIPTION
* Update crazyflie_cpp to upload trajectory pieces one-by-one (waiting for the result), similar to how we handle firmware communication issues for reading the various TOCs or parameters
* Changing the Python layer to make uploadTrajectory a blocking call, i.e., waiting until the upload succeeded

Fixes #390