### PR TITLE
systemtests: use non-default domain id

### DIFF
--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -39,6 +39,7 @@ jobs:
           source /opt/ros/humble/setup.bash
           . install/local_setup.bash
           export ROS_LOCALHOST_ONLY=1
+          export ROS_DOMAIN_ID=99
           python3 src/crazyswarm2/systemtests/test_flights.py
 
       - name: Upload files

--- a/docs2/conf.py
+++ b/docs2/conf.py
@@ -62,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Crazyswarm2'
-copyright = '2021-2022, Wolfgang Hönig (IMRClab), Kimberly McGuire (Bitcraze AB) and contributors'
+copyright = '2021-2024, Wolfgang Hönig (TU Berlin), Kimberly McGuire (Bitcraze AB), and contributors'
 author = 'Wolfgang Hönig, Kimberly McGuire'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -19,6 +19,11 @@ Usage
     .. code-block:: bash
 
         export ROS_LOCALHOST_ONLY=1
+        export ROS_DOMAIN_ID=<unique number between 0 and 101>
+
+    The first environment variable restricts ROS to your local machine. The second is useful
+    if you have multiple user accounts on the same machine (e.g., a shared workstation computer).
+    In such case, each user should use a unique `domain ID <https://docs.ros.org/en/iron/Concepts/Intermediate/About-Domain-ID.html>`_.
 
 
 Configuration


### PR DESCRIPTION
This should avoid interference with systemtests running on the same machine as flight tests