### PR TITLE
crazyflie_examples: add launch.py

### DIFF
--- a/crazyflie_examples/launch/launch.py
+++ b/crazyflie_examples/launch/launch.py
@@ -1,0 +1,50 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    script = LaunchConfiguration('script')
+    backend = LaunchConfiguration('backend')
+
+    script_launch_arg = DeclareLaunchArgument(
+        'script'
+    )
+
+    backend_launch_arg = DeclareLaunchArgument(
+        'backend',
+        default_value='cpp'
+    )
+
+    crazyflie = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('crazyflie'), 'launch'),
+            '/launch.py']),
+        launch_arguments={
+            'backend': backend,
+            }.items()
+    )
+
+    example_node = Node(
+        package='crazyflie_examples',
+        executable=script,
+        name=script,
+        parameters=[{
+            'use_sim_time': PythonExpression(["'", backend, "' == 'sim'"]),
+        }]
+    )
+
+    return LaunchDescription([
+        script_launch_arg,
+        backend_launch_arg,
+        crazyflie,
+        example_node
+    ])

--- a/docs2/usage.rst
+++ b/docs2/usage.rst
@@ -129,6 +129,12 @@ Example:
 
 .. code-block:: bash
 
+    [terminal]$ ros2 launch crazyflie_examples launch.py script:=hello_world backend:=sim
+
+which is a short-hand for the following two commands:
+
+.. code-block:: bash
+
     [terminal1]$ ros2 launch crazyflie launch.py backend:=sim
     [terminal2]$ ros2 run crazyflie_examples hello_world --ros-args -p use_sim_time:=True
 
@@ -155,6 +161,12 @@ You may run the script multiple times or different scripts while leaving the ser
 
     [terminal1]$ ros2 launch crazyflie launch.py
     [terminal2]$ ros2 run crazyflie_examples hello_world
+
+If you only want to run a single script once, you can also use:
+
+.. code-block:: bash
+
+    [terminal]$ ros2 launch crazyflie_examples launch.py script:=hello_world
 
 Swarm Management
 ----------------


### PR DESCRIPTION
Fixes #433.

Note that including was always possible, so this just adds a (useful) example and updates the docs accordingly.