### PR TITLE
tryout for substitute launch argument - fails

### DIFF
--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -10,19 +10,28 @@ from launch.substitutions import LaunchConfiguration, PythonExpression
 
 
 def generate_launch_description():
+
+    config_folder = LaunchConfiguration('config_folder')
+    config_folder_launch_arg = DeclareLaunchArgument('config_folder',
+        default_value=os.path.join(get_package_share_directory('crazyflie'),
+        'config',
+        'crazyflies.yaml')),
+    
+
+
+
     # load crazyflies
     crazyflies_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
+        config_folder,
         'crazyflies.yaml')
+
 
     with open(crazyflies_yaml, 'r') as ymlfile:
         crazyflies = yaml.safe_load(ymlfile)
 
     # server params
     server_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
+        config_folder,
         'server.yaml')
 
     with open(server_yaml, 'r') as ymlfile:
@@ -41,8 +50,7 @@ def generate_launch_description():
 
     # construct motion_capture_configuration
     motion_capture_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
+        config_folder,
         'motion_capture.yaml')
 
     with open(motion_capture_yaml, 'r') as ymlfile:
@@ -64,8 +72,7 @@ def generate_launch_description():
 
     # teleop params
     teleop_params = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
+        config_folder,
         'teleop.yaml')
 
     return LaunchDescription([
@@ -73,6 +80,7 @@ def generate_launch_description():
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),
         DeclareLaunchArgument('gui', default_value='True'),
+        config_folder_launch_arg,
         Node(
             package='motion_capture_tracking',
             executable='motion_capture_tracking_node',


### PR DESCRIPTION
Trying to solve #430, however this doesn't work due to this error:

```
ros2 launch crazyflie launch.py backend:=sim config_folder:='/home/kimberly/Documents/csw2_config'
[INFO] [launch]: All log files can be found below /home/kimberly/.ros/log/2024-03-07-16-36-11-797281-pop-os-10935
[INFO] [launch]: Default logging verbosity is set to INFO
<launch.substitutions.launch_configuration.LaunchConfiguration object at 0x7954fb6c7af0>
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: expected str, bytes or os.PathLike object, not LaunchConfiguration
```