### PR TITLE
server yaml file substitute with temporary files

### DIFF
--- a/crazyflie/config/crazyflies.yaml
+++ b/crazyflie/config/crazyflies.yaml
@@ -3,7 +3,7 @@ robots:
   cf231:
     enabled: true
     uri: radio://0/80/2M/E7E7E7E7E7
-    initial_position: [0, 0, 0]
+    initial_position: [0.0, 0.0, 0.0]
     type: cf21  # see robot_types
     # firmware_params:
     #   kalman:
@@ -17,7 +17,7 @@ robots:
   cf5:
     enabled: false
     uri: radio://0/80/2M/E7E7E7E705
-    initial_position: [0, -0.5, 0]
+    initial_position: [0.0, -0.5, 0.0]
     type: cf21  # see robot_types
     # firmware_params:
     #   kalman:

--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -10,6 +10,9 @@ from launch.substitutions import LaunchConfiguration, PythonExpression
 
 
 def generate_launch_description():
+
+    server_yaml_file = LaunchConfiguration('server_yaml_file')
+
     # load crazyflies
     crazyflies_yaml = os.path.join(
         get_package_share_directory('crazyflie'),
@@ -62,6 +65,11 @@ def generate_launch_description():
     # copy relevent settings to server params
     server_params[1]["poses_qos_deadline"] = motion_capture_params["topics"]["poses"]["qos"]["deadline"]
 
+    #print as yaml
+    print(yaml.dump(server_params, default_flow_style=False, sort_keys=False))
+    #with open('/data.yml', 'w') as outfile:
+    #    yaml.dump(server_params, outfile, default_flow_style=False, sort_keys=False)
+
     # teleop params
     teleop_params = os.path.join(
         get_package_share_directory('crazyflie'),
@@ -72,7 +80,8 @@ def generate_launch_description():
         DeclareLaunchArgument('backend', default_value='cpp'),
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),
-        DeclareLaunchArgument('gui', default_value='True'),
+        DeclareLaunchArgument('gui', default_value='False'),
+        DeclareLaunchArgument('server_yaml_file', default_value="test.yml"),
         Node(
             package='motion_capture_tracking',
             executable='motion_capture_tracking_node',
@@ -107,7 +116,7 @@ def generate_launch_description():
             condition=LaunchConfigurationEquals('backend','cflib'),
             name='crazyflie_server',
             output='screen',
-            parameters=server_params
+            parameters=[server_yaml_file]
         ),
         Node(
             package='crazyflie',
@@ -115,7 +124,7 @@ def generate_launch_description():
             condition=LaunchConfigurationEquals('backend','cpp'),
             name='crazyflie_server',
             output='screen',
-            parameters=server_params,
+            parameters=[server_yaml_file],
             prefix=PythonExpression(['"xterm -e gdb -ex run --args" if ', LaunchConfiguration('debug'), ' else ""']),
         ),
         Node(
@@ -125,7 +134,7 @@ def generate_launch_description():
             name='crazyflie_server',
             output='screen',
             emulate_tty=True,
-            parameters=server_params
+            parameters=[server_yaml_file]
         ),
         Node(
             condition=LaunchConfigurationEquals('rviz', 'True'),

--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -27,11 +27,11 @@ def generate_launch_description():
         'server.yaml')
 
     with open(server_yaml, 'r') as ymlfile:
-        server_yaml_contents = yaml.safe_load(ymlfile)
+        server_yaml_content = yaml.safe_load(ymlfile)
 
-    server_yaml_contents["/crazyflie_server"]["ros__parameters"]['robots'] = crazyflies['robots']
-    server_yaml_contents["/crazyflie_server"]["ros__parameters"]['robot_types'] = crazyflies['robot_types']
-    server_yaml_contents["/crazyflie_server"]["ros__parameters"]['all'] = crazyflies['all']
+    server_yaml_content["/crazyflie_server"]["ros__parameters"]['robots'] = crazyflies['robots']
+    server_yaml_content["/crazyflie_server"]["ros__parameters"]['robot_types'] = crazyflies['robot_types']
+    server_yaml_content["/crazyflie_server"]["ros__parameters"]['all'] = crazyflies['all']
 
     # robot description
     urdf = os.path.join(
@@ -41,7 +41,7 @@ def generate_launch_description():
     with open(urdf, 'r') as f:
 
         robot_desc = f.read()
-    server_yaml_contents["/crazyflie_server"]["ros__parameters"]["robot_description"] = robot_desc
+    server_yaml_content["/crazyflie_server"]["ros__parameters"]["robot_description"] = robot_desc
 
     # construct motion_capture_configuration
     motion_capture_yaml = os.path.join(
@@ -50,28 +50,28 @@ def generate_launch_description():
         'motion_capture.yaml')
 
     with open(motion_capture_yaml, 'r') as ymlfile:
-        motion_capture_contents = yaml.safe_load(ymlfile)
+        motion_capture_content = yaml.safe_load(ymlfile)
 
-    motion_capture_contents["/motion_capture_tracking"]["ros__parameters"]["rigid_bodies"] = dict()
+    motion_capture_content["/motion_capture_tracking"]["ros__parameters"]["rigid_bodies"] = dict()
     for key, value in crazyflies["robots"].items():
         type = crazyflies["robot_types"][value["type"]]
         if value["enabled"] and type["motion_capture"]["enabled"]:
-            motion_capture_contents["/motion_capture_tracking"]["ros__parameters"]["rigid_bodies"][key] =  {
+            motion_capture_content["/motion_capture_tracking"]["ros__parameters"]["rigid_bodies"][key] =  {
                     "initial_position": value["initial_position"],
                     "marker": type["motion_capture"]["marker"],
                     "dynamics": type["motion_capture"]["dynamics"],
                 }
 
     # copy relevent settings to server params
-    server_yaml_contents["/crazyflie_server"]["ros__parameters"]["poses_qos_deadline"] = motion_capture_contents[
+    server_yaml_content["/crazyflie_server"]["ros__parameters"]["poses_qos_deadline"] = motion_capture_content[
         "/motion_capture_tracking"]["ros__parameters"]["topics"]["poses"]["qos"]["deadline"]
 
     # Save server and mocap in temp file such that nodes can read it out later
     with open('tmp_server.yaml', 'w') as outfile:
-        yaml.dump(server_yaml_contents, outfile, default_flow_style=False, sort_keys=False)
+        yaml.dump(server_yaml_content, outfile, default_flow_style=False, sort_keys=False)
 
     with open('tmp_motion_capture.yaml', 'w') as outfile:
-        yaml.dump(motion_capture_contents, outfile, default_flow_style=False, sort_keys=False)
+        yaml.dump(motion_capture_content, outfile, default_flow_style=False, sort_keys=False)
 
     return LaunchDescription([
         DeclareLaunchArgument('backend', default_value='cpp'),

--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -33,6 +33,14 @@ def generate_launch_description():
 
     server_params = [crazyflies] + [server_yaml_contents["/crazyflie_server"]["ros__parameters"]]
 
+
+
+    server_yaml_contents["/crazyflie_server"]["ros__parameters"]['robots'] = crazyflies['robots']
+    server_yaml_contents["/crazyflie_server"]["ros__parameters"]['robot_types'] = crazyflies['robot_types']
+    server_yaml_contents["/crazyflie_server"]["ros__parameters"]['all'] = crazyflies['all']
+
+    #print(server_params)
+
     # robot description
     urdf = os.path.join(
         get_package_share_directory('crazyflie'),
@@ -41,6 +49,8 @@ def generate_launch_description():
     with open(urdf, 'r') as f:
         robot_desc = f.read()
     server_params[1]["robot_description"] = robot_desc
+    server_yaml_contents["/crazyflie_server"]["ros__parameters"]["robot_description"] = robot_desc
+
 
     # construct motion_capture_configuration
     motion_capture_yaml = os.path.join(
@@ -65,10 +75,17 @@ def generate_launch_description():
     # copy relevent settings to server params
     server_params[1]["poses_qos_deadline"] = motion_capture_params["topics"]["poses"]["qos"]["deadline"]
 
+    server_yaml_contents["/crazyflie_server"]["ros__parameters"]["poses_qos_deadline"] = motion_capture_params["topics"]["poses"]["qos"]["deadline"]
+
+    #print(server_yaml_contents) 
     #print as yaml
-    print(yaml.dump(server_params, default_flow_style=False, sort_keys=False))
-    #with open('/data.yml', 'w') as outfile:
-    #    yaml.dump(server_params, outfile, default_flow_style=False, sort_keys=False)
+    print('hello')
+    print(yaml.dump(server_yaml_contents, default_flow_style=False, sort_keys=False))
+    print('hello2')
+
+    yaml_file = yaml.dump(server_params, default_flow_style=False, sort_keys=False)
+    with open('temp.yml', 'w') as outfile:
+        yaml.dump(server_yaml_contents, outfile, default_flow_style=False, sort_keys=False)
 
     # teleop params
     teleop_params = os.path.join(
@@ -80,8 +97,8 @@ def generate_launch_description():
         DeclareLaunchArgument('backend', default_value='cpp'),
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),
-        DeclareLaunchArgument('gui', default_value='False'),
-        DeclareLaunchArgument('server_yaml_file', default_value="test.yml"),
+        DeclareLaunchArgument('gui', default_value='True'),
+        DeclareLaunchArgument('server_yaml_file', default_value=''),
         Node(
             package='motion_capture_tracking',
             executable='motion_capture_tracking_node',
@@ -134,7 +151,7 @@ def generate_launch_description():
             name='crazyflie_server',
             output='screen',
             emulate_tty=True,
-            parameters=[server_yaml_file]
+            parameters= [PythonExpression(["'temp.yml' if '", LaunchConfiguration('server_yaml_file'), "' == '' else '", LaunchConfiguration('server_yaml_file'), "'"])],
         ),
         Node(
             condition=LaunchConfigurationEquals('rviz', 'True'),


### PR DESCRIPTION
I figured out a solution that kind of works here without much change on the user side. So if  the user just does this:

```
ros2 launch crazyflie launch.py backend:=sim
```

Nothing changes really, except for there is a tmp file that is made especially for the server

but if the user defines a yaml file with different parameters like here

```
ros2 launch crazyflie launch.py backend:=sim server_yaml_file:='test.yaml'
```

then the server is initialized with that yaml file instead, which should include all the parameters necessary for that server.

I don't like that a temporary yaml file needs to be made in order for this to work. On the other hand, it also provides a template which users can use to make an modify their own yaml file.