### PR TITLE
Feature download usd python layer

### DIFF
--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -1,6 +1,8 @@
 #include <memory>
 #include <vector>
 #include <regex>
+#include <iostream>
+#include <fstream>
 
 #include <crazyflie_cpp/Crazyflie.h>
 
@@ -1428,13 +1430,9 @@ private:
     }
   }
 
-  /////////// put this somewhere else. Dependancy with crazyflie_cpp ok here ?
-  #include <iostream>
-  #include <fstream>
-
-  #include <crazyflie_cpp/Crazyflie.h>
-  bool download_USD(std::string outputfile, std::string uri = "radio://0/80/2M/E7E7E7E7E7", bool verbose = False) 
+  bool download_USD(std::string outputfile, std::string uri = "radio://0/80/2M/E7E7E7E7E7", bool verbose = false) 
   {
+    RCLCPP_INFO(logger_, "download_USD cpp was called");
     try
     {
       Crazyflie cf(uri);

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -1428,6 +1428,76 @@ private:
     }
   }
 
+  /////////// put this somewhere else. Dependancy with crazyflie_cpp ok here ?
+  #include <iostream>
+  #include <fstream>
+
+  #include <crazyflie_cpp/Crazyflie.h>
+  bool download_USD(std::string outputfile, std::string uri = "radio://0/80/2M/E7E7E7E7E7", bool verbose = False) 
+  {
+    try
+    {
+      Crazyflie cf(uri);
+      cf.requestParamToc();
+
+      const Crazyflie::ParamTocEntry* bcUSD = cf.getParamTocEntry("deck", "bcUSD");
+      const Crazyflie::ParamTocEntry* logging = cf.getParamTocEntry("usd", "logging");
+
+      if (bcUSD && logging) {
+        if (cf.getParam<uint8_t>(bcUSD->id) != 1) {
+          std::cerr << "USD deck is not initialized!" << std::endl;
+          return 1;
+        }
+        if (cf.getParam<uint8_t>(logging->id) != 0) {
+          std::cout << "Logging still enabled. Disabling logging." << std::endl;
+          cf.setParam<uint8_t>(logging->id, 0);
+          // return 1;
+        }
+      } else {
+        std::cerr << "Could not find USD deck logging variables! Are you using the latest firmware?" << std::endl;
+        return 1;
+      }
+
+      cf.requestMemoryToc();
+
+      if (verbose) {
+        auto iter = cf.memoriesBegin();
+        const auto end = cf.memoriesEnd();
+        for (;iter != end; ++iter) {
+          if (iter->type == Crazyflie::MemoryTypeUSD) {
+            std::cout << "File is " << iter->size << " bytes." << std::endl;
+            break;
+          }
+        }
+      }
+
+      std::vector<uint8_t> data;
+
+      auto start = std::chrono::high_resolution_clock::now();
+      cf.readUSDLogFile(data);
+      auto end = std::chrono::high_resolution_clock::now();
+      
+      if (verbose) {
+        std::chrono::duration<double> duration = end-start;
+        double t = duration.count();
+
+        std::cout << "read " << data.size() << " in " << t << " s. (" << data.size() / t << " B/s)." << std::endl;
+      }
+
+      std::cout << "read " << data.size() << std::endl;
+
+      std::ofstream out(outputfile, std::ios::binary);
+      out.write(reinterpret_cast<const char*>(data.data()), data.size());
+
+      return 0;
+    }
+    catch(std::exception& e)
+    {
+      std::cerr << e.what() << std::endl;
+      return 1;
+    }
+  }
+
   private:
     rclcpp::Logger logger_;
 

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -14,6 +14,7 @@
 #include "crazyflie_interfaces/srv/land.hpp"
 #include "crazyflie_interfaces/srv/go_to.hpp"
 #include "crazyflie_interfaces/srv/notify_setpoints_stop.hpp"
+#include "crazyflie_interfaces/srv/download_usd.hpp" ////////////////////////////////////////////
 #include "std_msgs/msg/string.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
@@ -36,6 +37,7 @@ using crazyflie_interfaces::srv::Land;
 using crazyflie_interfaces::srv::GoTo;
 using crazyflie_interfaces::srv::UploadTrajectory;
 using crazyflie_interfaces::srv::NotifySetpointsStop;
+using crazyflie_interfaces::srv::DownloadUSD; /////////////////////////////////////////////////
 using std_srvs::srv::Empty;
 
 using motion_capture_tracking_interfaces::msg::NamedPoseArray;
@@ -163,7 +165,7 @@ public:
     service_go_to_ = node->create_service<GoTo>(name + "/go_to", std::bind(&CrazyflieROS::go_to, this, _1, _2), service_qos, callback_group_cf_srv);
     service_upload_trajectory_ = node->create_service<UploadTrajectory>(name + "/upload_trajectory", std::bind(&CrazyflieROS::upload_trajectory, this, _1, _2), service_qos, callback_group_cf_srv);
     service_notify_setpoints_stop_ = node->create_service<NotifySetpointsStop>(name + "/notify_setpoints_stop", std::bind(&CrazyflieROS::notify_setpoints_stop, this, _1, _2), service_qos, callback_group_cf_srv);
-
+    service_download_usd_ = node->create_service<DownloadUSD>(name + "/download_usd", std::bind(&CrazyflieROS::download_usd, this, _1, _2), service_qos, callback_group_cf_srv);
     // Topics
 
     subscription_cmd_vel_legacy_ = node->create_subscription<geometry_msgs::msg::Twist>(name + "/cmd_vel_legacy", rclcpp::SystemDefaultsQoS(), std::bind(&CrazyflieROS::cmd_vel_legacy_changed, this, _1), sub_opt_cf_cmd);
@@ -900,6 +902,34 @@ private:
     last_on_latency_ = std::chrono::steady_clock::now();
   }
 
+  void download_usd(const std::shared_ptr<DownloadUSD::Request> request,
+                         std::shared_ptr<DownloadUSD::Response> response)
+  {
+    // bool verbose = request->verbose;
+    // std::string outputfile = request->outputfile;
+    RCLCPP_INFO(logger_, "call to download_usd");
+    bool verbose = true; //change this later to actually use the arguments passed in the srv request
+    std::string outputfile = "SDlogresult"; //change this later to actually use the arguments passed in the srv request
+    std::vector<uint8_t> data;
+
+    auto start = std::chrono::high_resolution_clock::now();
+    cf_.readUSDLogFile(data);
+    auto end = std::chrono::high_resolution_clock::now();
+    
+    if (verbose) {
+      std::chrono::duration<double> duration = end-start;
+      double t = duration.count();
+
+      std::cout << "read " << data.size() << " in " << t << " s. (" << data.size() / t << " B/s)." << std::endl;
+    }
+
+    std::cout << "read " << data.size() << std::endl;
+
+    std::ofstream out(outputfile, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(data.data()), data.size());
+    return;
+  }
+
 private:
   rclcpp::Logger logger_;
   CrazyflieLogger cf_logger_;
@@ -918,6 +948,7 @@ private:
   rclcpp::Service<GoTo>::SharedPtr service_go_to_;
   rclcpp::Service<UploadTrajectory>::SharedPtr service_upload_trajectory_;
   rclcpp::Service<NotifySetpointsStop>::SharedPtr service_notify_setpoints_stop_;
+  rclcpp::Service<DownloadUSD>::SharedPtr service_download_usd_;
 
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr subscription_cmd_vel_legacy_;
   rclcpp::Subscription<crazyflie_interfaces::msg::FullState>::SharedPtr subscription_cmd_full_state_;
@@ -1100,6 +1131,7 @@ public:
     service_land_ = this->create_service<Land>("all/land", std::bind(&CrazyflieServer::land, this, _1, _2), service_qos, callback_group_all_srv_);
     service_go_to_ = this->create_service<GoTo>("all/go_to", std::bind(&CrazyflieServer::go_to, this, _1, _2), service_qos, callback_group_all_srv_);
     service_notify_setpoints_stop_ = this->create_service<NotifySetpointsStop>("all/notify_setpoints_stop", std::bind(&CrazyflieServer::notify_setpoints_stop, this, _1, _2), service_qos, callback_group_all_srv_);
+    // service_download_usd_ = this->create_service<DownloadUSD>("all/download_usd", std::bind(&CrazyflieServer::download_usd, this, _1, _2), service_qos, callback_group_all_srv_);
 
     // This is the last service to announce and can be used to check if the server is fully available
     service_emergency_ = this->create_service<Empty>("all/emergency", std::bind(&CrazyflieServer::emergency, this, _1, _2), service_qos, callback_group_all_srv_);
@@ -1427,72 +1459,6 @@ private:
       RCLCPP_WARN(logger_, "[all] At least two objects with the same id (%d, %s, %s)", id, name.c_str(), iter->first.c_str());
     } else {
       name_to_id_.insert(std::make_pair(name, id));
-    }
-  }
-
-  bool download_USD(std::string outputfile, std::string uri = "radio://0/80/2M/E7E7E7E7E7", bool verbose = false) 
-  {
-    RCLCPP_INFO(logger_, "download_USD cpp was called");
-    try
-    {
-      Crazyflie cf(uri);
-      cf.requestParamToc();
-
-      const Crazyflie::ParamTocEntry* bcUSD = cf.getParamTocEntry("deck", "bcUSD");
-      const Crazyflie::ParamTocEntry* logging = cf.getParamTocEntry("usd", "logging");
-
-      if (bcUSD && logging) {
-        if (cf.getParam<uint8_t>(bcUSD->id) != 1) {
-          std::cerr << "USD deck is not initialized!" << std::endl;
-          return 1;
-        }
-        if (cf.getParam<uint8_t>(logging->id) != 0) {
-          std::cout << "Logging still enabled. Disabling logging." << std::endl;
-          cf.setParam<uint8_t>(logging->id, 0);
-          // return 1;
-        }
-      } else {
-        std::cerr << "Could not find USD deck logging variables! Are you using the latest firmware?" << std::endl;
-        return 1;
-      }
-
-      cf.requestMemoryToc();
-
-      if (verbose) {
-        auto iter = cf.memoriesBegin();
-        const auto end = cf.memoriesEnd();
-        for (;iter != end; ++iter) {
-          if (iter->type == Crazyflie::MemoryTypeUSD) {
-            std::cout << "File is " << iter->size << " bytes." << std::endl;
-            break;
-          }
-        }
-      }
-
-      std::vector<uint8_t> data;
-
-      auto start = std::chrono::high_resolution_clock::now();
-      cf.readUSDLogFile(data);
-      auto end = std::chrono::high_resolution_clock::now();
-      
-      if (verbose) {
-        std::chrono::duration<double> duration = end-start;
-        double t = duration.count();
-
-        std::cout << "read " << data.size() << " in " << t << " s. (" << data.size() / t << " B/s)." << std::endl;
-      }
-
-      std::cout << "read " << data.size() << std::endl;
-
-      std::ofstream out(outputfile, std::ios::binary);
-      out.write(reinterpret_cast<const char*>(data.data()), data.size());
-
-      return 0;
-    }
-    catch(std::exception& e)
-    {
-      std::cerr << e.what() << std::endl;
-      return 1;
     }
   }
 

--- a/crazyflie_examples/crazyflie_examples/hello_world.py
+++ b/crazyflie_examples/crazyflie_examples/hello_world.py
@@ -11,7 +11,9 @@ def main():
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     cf = swarm.allcfs.crazyflies[0]
-
+    print("downloading")
+    cf.downloadUSD("/home/julien/testUSDdownload", verbose = True)
+    print("end downloading")
     cf.takeoff(targetHeight=1.0, duration=TAKEOFF_DURATION)
     timeHelper.sleep(TAKEOFF_DURATION + HOVER_DURATION)
     cf.land(targetHeight=0.04, duration=2.5)

--- a/crazyflie_examples/crazyflie_examples/hello_world.py
+++ b/crazyflie_examples/crazyflie_examples/hello_world.py
@@ -12,6 +12,7 @@ def main():
     timeHelper = swarm.timeHelper
     cf = swarm.allcfs.crazyflies[0]
     cf.takeoff(targetHeight=1.0, duration=TAKEOFF_DURATION)
+    
     timeHelper.sleep(TAKEOFF_DURATION + HOVER_DURATION)
     cf.land(targetHeight=0.04, duration=2.5)
     timeHelper.sleep(TAKEOFF_DURATION)

--- a/crazyflie_examples/crazyflie_examples/hello_world.py
+++ b/crazyflie_examples/crazyflie_examples/hello_world.py
@@ -11,9 +11,6 @@ def main():
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     cf = swarm.allcfs.crazyflies[0]
-    print("downloading")
-    cf.downloadUSD("/home/julien/testUSDdownload", verbose = True)
-    print("end downloading")
     cf.takeoff(targetHeight=1.0, duration=TAKEOFF_DURATION)
     timeHelper.sleep(TAKEOFF_DURATION + HOVER_DURATION)
     cf.land(targetHeight=0.04, duration=2.5)

--- a/crazyflie_examples/crazyflie_examples/hello_world.py
+++ b/crazyflie_examples/crazyflie_examples/hello_world.py
@@ -11,8 +11,8 @@ def main():
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     cf = swarm.allcfs.crazyflies[0]
-    cf.takeoff(targetHeight=1.0, duration=TAKEOFF_DURATION)
     
+    cf.takeoff(targetHeight=1.0, duration=TAKEOFF_DURATION)
     timeHelper.sleep(TAKEOFF_DURATION + HOVER_DURATION)
     cf.land(targetHeight=0.04, duration=2.5)
     timeHelper.sleep(TAKEOFF_DURATION)

--- a/crazyflie_examples/crazyflie_examples/hello_world.py
+++ b/crazyflie_examples/crazyflie_examples/hello_world.py
@@ -11,7 +11,7 @@ def main():
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     cf = swarm.allcfs.crazyflies[0]
-    
+
     cf.takeoff(targetHeight=1.0, duration=TAKEOFF_DURATION)
     timeHelper.sleep(TAKEOFF_DURATION + HOVER_DURATION)
     cf.land(targetHeight=0.04, duration=2.5)

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -12,60 +12,88 @@ def main():
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     allcfs = swarm.allcfs
-    # time.sleep(2)
-    # for cf in allcfs.crazyflies:
-    #     status =  cf.get_status()
-    #     print(status)
-
-
-
-        # from time import sleep
-        # while True:
-        #     status, counter = cf.get_status()
-        #     print(status)
-        #     sleep(0.1)
-        # id, sec, nsec, s, b, p, r, rxb, txb, rxu, txu = status.values()
-        # print(f"{cf.prefix} : {id}, {sec}, {nsec}, {s}, {b}, {p}, {r}, {rxb}, {rxu}, {txb}, {txu} ")
 
     traj1 = Trajectory()
     traj1.loadcsv(Path(__file__).parent / 'data/figure8.csv')
 
+    
+
     TIMESCALE = 1.0
     for cf in allcfs.crazyflies:
         cf.uploadTrajectory(0, 0, traj1)
+    timeHelper.sleep(1)
+        
+           
+     #pm_state :     0 = on battery ;  1 = charging  ;   2 = charged     ;  3 = low power  ; 4 = shutdown    
+    flight_counter = 1 
+       
+    while True : 
+        print("takeoff")
+        allcfs.takeoff(targetHeight=1.0, duration=2.0)
+        timeHelper.sleep(2.5)
+        for cf in allcfs.crazyflies:
+            pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+            cf.goTo(pos, 0, 2.0)
+        timeHelper.sleep(2.5)
 
-    allcfs.takeoff(targetHeight=1.0, duration=2.0)
-    timeHelper.sleep(2.5)
-    for cf in allcfs.crazyflies:
-        pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
-        cf.goTo(pos, 0, 2.0)
-    timeHelper.sleep(2.5)
+        #fly figure8 until battery is low
+        fig8_counter = 0
+        status = allcfs.get_statuses()[0]
+        # while status['battery'] > 3.8:
+        while status['pm_state'] == 0:
+            fig8_counter += 1
+            print(f"starting figure8 number {fig8_counter} of flight number {flight_counter}")
+            allcfs.startTrajectory(0, timescale=TIMESCALE)
+            timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
+            status = allcfs.get_statuses()[0]
+            print(f"pm state : {status['pm_state']}, battery left : {status['battery']}")
+            timeHelper.sleep(1)
+        
+        
+        #not sure if useful
+        #check if pm = 3 just to be sure, if not abort test 
+        if status['pm_state'] != 3:
+            print(f"power state is not 3 (low) but {status['pm_state']}. Landing and aborting")
+            allcfs.land(targetHeight=0.06, duration=2.0)
+            timeHelper.sleep(3)
+            return 1                    
+        
 
-    allcfs.startTrajectory(0, timescale=TIMESCALE)
-    timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
 
 
-    timeHelper.sleep(2.5)
-    status = allcfs.status()        #NB what happens if we have multiple CFs ? 
-    print(f"battery {status.battery}")
+        #now that battery is low, we try to land on the pad and see if it's charging
+        allcfs.land(targetHeight=0.06, duration=2.0)
+        timeHelper.sleep(5)
+        status = allcfs.get_statuses()[0]
 
-    ###second figure8
-    allcfs.startTrajectory(0, TIMESCALE)
-    timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
+        #if not charging, take off and land back again until it charges
+        while status['pm_state'] != 1:
+            print("Not charging, retrying")
+            allcfs.takeoff(targetHeight=1.0, duration=2.0)
+            time.sleep(2.5)
+            for cf in allcfs.crazyflies:
+                pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+            cf.goTo(pos, 0, 2.0)
+            timeHelper.sleep(2.5)
+            allcfs.land(targetHeight=0.06, duration=2.0)
+            timeHelper.sleep(5)
+            status = allcfs.get_statuses()[0]       
 
-
-    allcfs.land(targetHeight=0.06, duration=2.0)
-    timeHelper.sleep(3)
-    status = allcfs.status()
-    while status.pm_state != 1:
-        print("Not charging, retrying")
-        allcfs.takeoff(targetHeight=0.5, duration=1.0)
-        timeHelper.sleep(1.5)
-        allcfs.land(targetHeight=0.06, duration=1.0)
-        timeHelper.sleep(2)
-
-    print("charging !")
-    timeHelper.sleep(3.0)
+    
+    
+        #now we wait until the crazyflie is charged
+        # while status['battery'] < 4.1:
+        while status['pm_state'] != 2:
+            print(f"not charged yet, battery at {status['battery']}V")
+            timeHelper.sleep(60)
+            status = allcfs.get_statuses()[0]
+            ###not sure if useful
+            #check if it's still charging
+            if status['pm_state'] != 1:
+                print(f"charging interrupted, pm state : {status['pm_state']}")
+            
+        print("charging finished, time to fly again")
+        flight_counter += 1
 
 
 if __name__ == '__main__':

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -43,7 +43,7 @@ def main():
             allcfs.startTrajectory(0, timescale=TIMESCALE)
             timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
             status = allcfs.get_statuses()[0]
-            print(f'pm state : {status['pm_state']}, battery left : {status['battery']}')
+            print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
             timeHelper.sleep(1)
         
         

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -35,14 +35,14 @@ def main():
 
         # fly figure8 until battery is low
         fig8_counter = 0
-        status = allcfs.crazyflies[0].status()# status = allcfs.get_statuses()[0]
+        status = allcfs.crazyflies[0].get_status()
         # while status['battery'] > 3.8:
         while status['pm_state'] == 0:
             fig8_counter += 1
             print(f'starting figure8 number {fig8_counter} of flight number {flight_counter}')
             allcfs.startTrajectory(0, timescale=TIMESCALE)
             timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
-            status = allcfs.crazyflies[0].status() # status = allcfs.get_statuses()[0]
+            status = allcfs.crazyflies[0].get_status()
             print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
             timeHelper.sleep(1)
         
@@ -61,7 +61,7 @@ def main():
         # now that battery is low, we try to land on the pad and see if it's charging
         allcfs.land(targetHeight=0.06, duration=2.0)
         timeHelper.sleep(5)
-        status = allcfs.crazyflies[0].status() # status = allcfs.get_statuses()[0]
+        status = allcfs.crazyflies[0].get_status()
 
         # if not charging, take off and land back again until it charges
         while status['pm_state'] != 1:
@@ -74,20 +74,20 @@ def main():
             timeHelper.sleep(2.5)
             allcfs.land(targetHeight=0.06, duration=2.0)
             timeHelper.sleep(5)
-            status = allcfs.crazyflies[0].status() # status = allcfs.get_statuses()[0]
+            status = allcfs.crazyflies[0].get_status()
 
 
         # now we wait until the crazyflie is charged
         # while status['battery'] < 4.1:
         while status['pm_state'] != 2:
-            print(f'not charged yet, battery at {status['battery']}V')
+            print(f'Charging in progress, battery at {status["battery"]}V')
             timeHelper.sleep(60)
-            status = allcfs.crazyflies[0].status( )#status = allcfs.get_statuses()[0]
+            status = allcfs.crazyflies[0].get_status()
             #check if it's still charging ###not sure if this check is useful
             if status['pm_state'] != 1:
-                print(f'charging interrupted, pm state : {status['pm_state']}')
+                print(f'charging interrupted, pm state : {status["pm_state"]}')
 
-        print('charging finished, time to fly again')
+        print('Charging finished, time to fly again')
         flight_counter += 1
 
 

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -35,14 +35,14 @@ def main():
 
         # fly figure8 until battery is low
         fig8_counter = 0
-        status = allcfs.get_statuses()[0]
+        status = allcfs.crazyflies[0].status()# status = allcfs.get_statuses()[0]
         # while status['battery'] > 3.8:
         while status['pm_state'] == 0:
             fig8_counter += 1
             print(f'starting figure8 number {fig8_counter} of flight number {flight_counter}')
             allcfs.startTrajectory(0, timescale=TIMESCALE)
             timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
-            status = allcfs.get_statuses()[0]
+            status = allcfs.crazyflies[0].status() # status = allcfs.get_statuses()[0]
             print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
             timeHelper.sleep(1)
         
@@ -50,7 +50,7 @@ def main():
         # not sure if useful
         # check if pm = 3 just to be sure, if not abort test 
         if status['pm_state'] != 3:
-            print(f'power state is not 3 (low) but {status['pm_state']}. Landing and aborting')
+            print(f'power state is not 3 (low) but {status["pm_state"]}. Landing and aborting')
             allcfs.land(targetHeight=0.06, duration=2.0)
             timeHelper.sleep(3)
             return 1                    
@@ -61,7 +61,7 @@ def main():
         # now that battery is low, we try to land on the pad and see if it's charging
         allcfs.land(targetHeight=0.06, duration=2.0)
         timeHelper.sleep(5)
-        status = allcfs.get_statuses()[0]
+        status = allcfs.crazyflies[0].status() # status = allcfs.get_statuses()[0]
 
         # if not charging, take off and land back again until it charges
         while status['pm_state'] != 1:
@@ -74,7 +74,7 @@ def main():
             timeHelper.sleep(2.5)
             allcfs.land(targetHeight=0.06, duration=2.0)
             timeHelper.sleep(5)
-            status = allcfs.get_statuses()[0]
+            status = allcfs.crazyflies[0].status() # status = allcfs.get_statuses()[0]
 
 
         # now we wait until the crazyflie is charged
@@ -82,9 +82,8 @@ def main():
         while status['pm_state'] != 2:
             print(f'not charged yet, battery at {status['battery']}V')
             timeHelper.sleep(60)
-            status = allcfs.get_statuses()[0]
-            ###not sure if useful
-            #check if it's still charging
+            status = allcfs.crazyflies[0].status( )#status = allcfs.get_statuses()[0]
+            #check if it's still charging ###not sure if this check is useful
             if status['pm_state'] != 1:
                 print(f'charging interrupted, pm state : {status['pm_state']}')
 

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+
+from crazyflie_py import Crazyswarm
+from crazyflie_py.uav_trajectory import Trajectory
+import numpy as np
+import time
+
+
+def main():
+    swarm = Crazyswarm()
+    timeHelper = swarm.timeHelper
+    allcfs = swarm.allcfs
+    # time.sleep(2)
+    # for cf in allcfs.crazyflies:
+    #     status =  cf.get_status()
+    #     print(status)
+
+
+
+        # from time import sleep
+        # while True:
+        #     status, counter = cf.get_status()
+        #     print(status)
+        #     sleep(0.1)
+        # id, sec, nsec, s, b, p, r, rxb, txb, rxu, txu = status.values()
+        # print(f"{cf.prefix} : {id}, {sec}, {nsec}, {s}, {b}, {p}, {r}, {rxb}, {rxu}, {txb}, {txu} ")
+
+    traj1 = Trajectory()
+    traj1.loadcsv(Path(__file__).parent / 'data/figure8.csv')
+
+    TIMESCALE = 1.0
+    for cf in allcfs.crazyflies:
+        cf.uploadTrajectory(0, 0, traj1)
+
+    allcfs.takeoff(targetHeight=1.0, duration=2.0)
+    timeHelper.sleep(2.5)
+    for cf in allcfs.crazyflies:
+        pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+        cf.goTo(pos, 0, 2.0)
+    timeHelper.sleep(2.5)
+
+    allcfs.startTrajectory(0, timescale=TIMESCALE)
+    timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
+
+
+    timeHelper.sleep(2.5)
+    status = allcfs.status()        #NB what happens if we have multiple CFs ? 
+    print(f"battery {status.battery}")
+
+    ###second figure8
+    allcfs.startTrajectory(0, TIMESCALE)
+    timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
+
+
+    allcfs.land(targetHeight=0.06, duration=2.0)
+    timeHelper.sleep(3)
+    status = allcfs.status()
+    while status.pm_state != 1:
+        print("Not charging, retrying")
+        allcfs.takeoff(targetHeight=0.5, duration=1.0)
+        timeHelper.sleep(1.5)
+        allcfs.land(targetHeight=0.06, duration=1.0)
+        timeHelper.sleep(2)
+
+    print("charging !")
+    timeHelper.sleep(3.0)
+
+
+if __name__ == '__main__':
+    main()

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -15,7 +15,6 @@ def main():
     traj1 = Trajectory()
     traj1.loadcsv(Path(__file__).parent / 'data/figure8.csv')
 
-
     TIMESCALE = 1.0
     for cf in allcfs.crazyflies:
         cf.uploadTrajectory(0, 0, traj1)
@@ -45,18 +44,14 @@ def main():
             status = allcfs.crazyflies[0].get_status()
             print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
             timeHelper.sleep(1)
-        
-        
+
         # not sure if useful
-        # check if pm = 3 just to be sure, if not abort test 
+        # check if pm = 3 just to be sure, if not abort test
         if status['pm_state'] != 3:
             print(f'power state is not 3 (low) but {status["pm_state"]}. Landing and aborting')
             allcfs.land(targetHeight=0.06, duration=2.0)
             timeHelper.sleep(3)
-            return 1                    
-
-
-
+            return 1
 
         # now that battery is low, we try to land on the pad and see if it's charging
         allcfs.land(targetHeight=0.06, duration=2.0)
@@ -76,14 +71,13 @@ def main():
             timeHelper.sleep(5)
             status = allcfs.crazyflies[0].get_status()
 
-
         # now we wait until the crazyflie is charged
         # while status['battery'] < 4.1:
         while status['pm_state'] != 2:
             print(f'Charging in progress, battery at {status["battery"]}V')
             timeHelper.sleep(60)
             status = allcfs.crazyflies[0].get_status()
-            #check if it's still charging ###not sure if this check is useful
+            # check if it's still charging ###not sure if this check is useful
             if status['pm_state'] != 1:
                 print(f'charging interrupted, pm state : {status["pm_state"]}')
 

--- a/crazyflie_examples/crazyflie_examples/infinite_flight.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from crazyflie_py import Crazyswarm
 from crazyflie_py.uav_trajectory import Trajectory
 import numpy as np
-import time
 
 
 def main():
@@ -16,19 +15,17 @@ def main():
     traj1 = Trajectory()
     traj1.loadcsv(Path(__file__).parent / 'data/figure8.csv')
 
-    
 
     TIMESCALE = 1.0
     for cf in allcfs.crazyflies:
         cf.uploadTrajectory(0, 0, traj1)
     timeHelper.sleep(1)
-        
-           
-     #pm_state :     0 = on battery ;  1 = charging  ;   2 = charged     ;  3 = low power  ; 4 = shutdown    
-    flight_counter = 1 
-       
-    while True : 
-        print("takeoff")
+
+    # pm_state : 0 = on battery  1 = charging  2 = charged  3 = low power  4 = shutdown
+    flight_counter = 1
+
+    while True:
+        print('takeoff')
         allcfs.takeoff(targetHeight=1.0, duration=2.0)
         timeHelper.sleep(2.5)
         for cf in allcfs.crazyflies:
@@ -36,63 +33,62 @@ def main():
             cf.goTo(pos, 0, 2.0)
         timeHelper.sleep(2.5)
 
-        #fly figure8 until battery is low
+        # fly figure8 until battery is low
         fig8_counter = 0
         status = allcfs.get_statuses()[0]
         # while status['battery'] > 3.8:
         while status['pm_state'] == 0:
             fig8_counter += 1
-            print(f"starting figure8 number {fig8_counter} of flight number {flight_counter}")
+            print(f'starting figure8 number {fig8_counter} of flight number {flight_counter}')
             allcfs.startTrajectory(0, timescale=TIMESCALE)
             timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
             status = allcfs.get_statuses()[0]
-            print(f"pm state : {status['pm_state']}, battery left : {status['battery']}")
+            print(f'pm state : {status['pm_state']}, battery left : {status['battery']}')
             timeHelper.sleep(1)
         
         
-        #not sure if useful
-        #check if pm = 3 just to be sure, if not abort test 
+        # not sure if useful
+        # check if pm = 3 just to be sure, if not abort test 
         if status['pm_state'] != 3:
-            print(f"power state is not 3 (low) but {status['pm_state']}. Landing and aborting")
+            print(f'power state is not 3 (low) but {status['pm_state']}. Landing and aborting')
             allcfs.land(targetHeight=0.06, duration=2.0)
             timeHelper.sleep(3)
             return 1                    
-        
 
 
 
-        #now that battery is low, we try to land on the pad and see if it's charging
+
+        # now that battery is low, we try to land on the pad and see if it's charging
         allcfs.land(targetHeight=0.06, duration=2.0)
         timeHelper.sleep(5)
         status = allcfs.get_statuses()[0]
 
-        #if not charging, take off and land back again until it charges
+        # if not charging, take off and land back again until it charges
         while status['pm_state'] != 1:
-            print("Not charging, retrying")
+            print('Not charging, retrying')
             allcfs.takeoff(targetHeight=1.0, duration=2.0)
-            time.sleep(2.5)
+            timeHelper.sleep(2.5)
             for cf in allcfs.crazyflies:
                 pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
             cf.goTo(pos, 0, 2.0)
             timeHelper.sleep(2.5)
             allcfs.land(targetHeight=0.06, duration=2.0)
             timeHelper.sleep(5)
-            status = allcfs.get_statuses()[0]       
+            status = allcfs.get_statuses()[0]
 
-    
-    
-        #now we wait until the crazyflie is charged
+
+        # now we wait until the crazyflie is charged
         # while status['battery'] < 4.1:
         while status['pm_state'] != 2:
-            print(f"not charged yet, battery at {status['battery']}V")
+            print(f'not charged yet, battery at {status['battery']}V')
             timeHelper.sleep(60)
             status = allcfs.get_statuses()[0]
             ###not sure if useful
             #check if it's still charging
             if status['pm_state'] != 1:
-                print(f"charging interrupted, pm state : {status['pm_state']}")
-            
-        print("charging finished, time to fly again")
+                print(f'charging interrupted, pm state : {status['pm_state']}')
+
+        print('charging finished, time to fly again')
         flight_counter += 1
 
 

--- a/crazyflie_examples/crazyflie_examples/infinite_flight_download.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight_download.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+
+from crazyflie_py import Crazyswarm
+from crazyflie_py.uav_trajectory import Trajectory
+import numpy as np
+
+import time
+import threading
+import shutil
+import os
+from subprocess import Popen, PIPE, TimeoutExpired, STDOUT
+import atexit
+import signal
+
+#supervisor bitfield constants
+CAN_BE_ARMED = 1    # 0b00000001
+IS_ARMED     = 2    # 0b00000010  
+AUTO_ARM     = 4    # 0b00000100
+CAN_FLY      = 8    # 0b00001000
+IS_FLYING    = 16   # 0b00010000
+IS_TUMBLED   = 32   # 0b00100000
+IS_LOCKED    = 64   # 0b01000000
+
+
+def is_crashed(swarm : Crazyswarm, ros2_ws):
+    print("function call is_crashed")
+    allcfs = swarm.allcfs
+    while True: 
+        # swarm.timeHelper.sleep(10)
+        time.sleep(10)
+        status = allcfs.crazyflies[0].get_status()
+        if status == {}:
+            print("status is an empty dictionary")
+            continue
+        print("while")
+        #if the CF is tumbled (32) or locked(64)
+        if (status['supervisor'] & IS_TUMBLED) or (status['supervisor'] & IS_LOCKED):
+        # if status['supervisor'] == 32 or status['supervisor'] == 64:
+            print("Crazyflie has crashed. Downloading logs and ending infinite_flight")
+            downloadSD_PIPE_file = str(ros2_ws) + "/infinite_flight_results/SD_download_PIPE.txt"
+            with open(downloadSD_PIPE_file, 'w') as f:
+                try:               
+                    src = "source " + str(ros2_ws) + '/install/setup.bash' 
+                    command = f"{src} && ros2 run crazyflie downloadUSDLogfile --output SDlogfile" #if CF doesn't use default URI, add --uri custom_uri (e.g --uri radio://0/80/2M/E7E7E7E70B)
+                    downloadSD= Popen(command, shell=True, stderr=STDOUT, stdout=f, text=True,         #download the log file in ....../ros2_ws/results/test_xxxxxxx/
+                                        cwd= ros2_ws / "infinite_flight_results" ,start_new_session=True, executable="/bin/bash") 
+                    atexit.register(clean_process, downloadSD)
+                    downloadSD.wait(timeout=180)
+                    f.write('success')
+                    # swarm.timeHelper.sleep(2)
+                    # time.sleep(2)
+                    print("download successful")
+                    exit(0)
+                    # raise TimeoutExpired
+                    
+                except TimeoutExpired:
+                    # clean_process(downloadSD)
+                    print("Downloading SD card data was killed for taking too long")
+                    f.write('\n \n \n#########################################################\n')
+                    f.write("Downloading SD card data was killed for taking too long !\n")
+                    f.write('#########################################################\n \n \n \n')
+                    exit(1)
+                     
+        else:
+            print("all good")
+            # return False
+            
+def clean_process(process:Popen) -> int :
+    '''Kills process and its children on exit if they aren't already terminated (called with atexit). Returns 0 on termination, 1 if SIGKILL was needed''' 
+    if process.poll() == None:
+        group_id = os.getpgid(process.pid)
+        print(f"cleaning process {group_id}")
+        os.killpg(group_id, signal.SIGTERM)
+        time.sleep(0.01) #necessary delay before first poll
+        i=0
+        while i < 10 and process.poll() == None:  #in case the process termination is lazy and takes some time, we wait up to 0.5 sec per process
+            if process.poll() != None:
+                return 0  #if we have a returncode-> it terminated
+            time.sleep(0.05) #if not wait a bit longer
+        if(i == 9):
+            os.killpg(group_id, signal.SIGKILL)
+            return 1  #after 0.5s we stop waiting, consider it did not terminate correctly and kill it
+        return 0
+    else:
+        return 0 #process already terminated
+
+
+def main():
+    
+    #delete previous logfiles if they exist
+    # if(Path(Path.home() / ".ros/log").exists()): #delete log files of the previous test
+        # shutil.rmtree(Path.home() / ".ros/log")
+    #create folder where the logfiles of the crash will be downloaded
+    ros2_ws = Path.home() / "ros2_ws"
+    if(Path(ros2_ws / "infinite_flight_results").exists()):
+        shutil.rmtree(ros2_ws / "infinite_flight_results")  
+    os.makedirs(ros2_ws / "infinite_flight_results")
+    
+    swarm = Crazyswarm()
+    timeHelper = swarm.timeHelper
+    allcfs = swarm.allcfs
+    # print("here")
+    check_crashed_thread = threading.Thread(target=is_crashed, args=(swarm,ros2_ws), daemon=True)
+    check_crashed_thread.start()
+    # print("there")
+    # exit(0)
+
+    traj1 = Trajectory()
+    traj1.loadcsv(Path(__file__).parent / 'data/figure8.csv')
+    
+    #enable logging
+    allcfs.setParam("usd.logging", 1)
+
+    TIMESCALE = 1.0
+    for cf in allcfs.crazyflies:
+        cf.uploadTrajectory(0, 0, traj1)
+    timeHelper.sleep(1)
+
+    # pm_state : 0 = on battery  1 = charging  2 = charged  3 = low power  4 = shutdown
+    flight_counter = 1
+
+    while True:
+        print('takeoff')
+        allcfs.takeoff(targetHeight=1.0, duration=2.0)
+        timeHelper.sleep(2.5)
+        for cf in allcfs.crazyflies:
+            pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+            cf.goTo(pos, 0, 2.0)
+        timeHelper.sleep(2.5)
+
+        # fly figure8 until battery is low
+        fig8_counter = 0
+        status = allcfs.crazyflies[0].get_status()
+        # while status['battery'] > 3.8:
+        while status['pm_state'] == 0:
+            fig8_counter += 1
+            print(f'starting figure8 number {fig8_counter} of flight number {flight_counter}')
+            allcfs.startTrajectory(0, timescale=TIMESCALE)
+            timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
+            status = allcfs.crazyflies[0].get_status()
+            print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
+            timeHelper.sleep(1)
+
+        # not sure if useful
+        # check if pm = 3 just to be sure, if not abort test
+        if status['pm_state'] != 3:
+            print(f'power state is not 3 (low) but {status["pm_state"]}. Landing and aborting')
+            allcfs.land(targetHeight=0.06, duration=2.0)
+            timeHelper.sleep(3)
+            return 1
+
+        # now that battery is low, we try to land on the pad and see if it's charging
+        allcfs.land(targetHeight=0.06, duration=2.0)
+        timeHelper.sleep(5)
+        status = allcfs.crazyflies[0].get_status()
+
+        # if not charging, take off and land back again until it charges
+        while status['pm_state'] != 1:
+            print('Not charging, retrying')
+            allcfs.takeoff(targetHeight=1.0, duration=2.0)
+            timeHelper.sleep(2.5)
+            for cf in allcfs.crazyflies:
+                pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+            cf.goTo(pos, 0, 2.0)
+            timeHelper.sleep(2.5)
+            allcfs.land(targetHeight=0.06, duration=2.0)
+            timeHelper.sleep(5)
+            status = allcfs.crazyflies[0].get_status()
+
+        # now we wait until the crazyflie is charged
+        while status['battery'] < 3.78:
+        # while status['pm_state'] != 2:
+            print(f'Charging in progress, battery at {status["battery"]}V')
+            timeHelper.sleep(60)
+            status = allcfs.crazyflies[0].get_status()
+            # check if it's still charging ###not sure if this check is useful
+            if status['pm_state'] != 1:
+                print(f'charging interrupted, pm state : {status["pm_state"]}')
+
+        print('Charging finished, time to fly again')
+        flight_counter += 1
+
+
+if __name__ == '__main__':
+    main()

--- a/crazyflie_examples/crazyflie_examples/infinite_flight_download.py
+++ b/crazyflie_examples/crazyflie_examples/infinite_flight_download.py
@@ -29,43 +29,47 @@ def is_crashed(swarm : Crazyswarm, ros2_ws):
     allcfs = swarm.allcfs
     while True: 
         # swarm.timeHelper.sleep(10)
-        time.sleep(10)
+        time.sleep(5)
         status = allcfs.crazyflies[0].get_status()
         if status == {}:
             print("status is an empty dictionary")
             continue
-        print("while")
+        print(status["supervisor"])
         #if the CF is tumbled (32) or locked(64)
         if (status['supervisor'] & IS_TUMBLED) or (status['supervisor'] & IS_LOCKED):
         # if status['supervisor'] == 32 or status['supervisor'] == 64:
             print("Crazyflie has crashed. Downloading logs and ending infinite_flight")
-            downloadSD_PIPE_file = str(ros2_ws) + "/infinite_flight_results/SD_download_PIPE.txt"
-            with open(downloadSD_PIPE_file, 'w') as f:
-                try:               
-                    src = "source " + str(ros2_ws) + '/install/setup.bash' 
-                    command = f"{src} && ros2 run crazyflie downloadUSDLogfile --output SDlogfile" #if CF doesn't use default URI, add --uri custom_uri (e.g --uri radio://0/80/2M/E7E7E7E70B)
-                    downloadSD= Popen(command, shell=True, stderr=STDOUT, stdout=f, text=True,         #download the log file in ....../ros2_ws/results/test_xxxxxxx/
-                                        cwd= ros2_ws / "infinite_flight_results" ,start_new_session=True, executable="/bin/bash") 
-                    atexit.register(clean_process, downloadSD)
-                    downloadSD.wait(timeout=180)
-                    f.write('success')
-                    # swarm.timeHelper.sleep(2)
-                    # time.sleep(2)
-                    print("download successful")
-                    exit(0)
-                    # raise TimeoutExpired
+            outputfile = str(ros2_ws) + "/infinite_flight_results/SDlogfile"
+            for cf in swarm.allcfs.crazyflies:
+                cf.downloadUSD(outputfile, verbose=True)
+            print("Sd download finished")
+            os._exit(0)
+            # downloadSD_PIPE_file = str(ros2_ws) + "/infinite_flight_results/SD_download_PIPE.txt"
+            # with open(downloadSD_PIPE_file, 'w') as f:
+            #     try:               
+            #         # src = "source " + str(ros2_ws) + '/install/setup.bash' 
+            #         # command = f"{src} && ros2 run crazyflie downloadUSDLogfile --output SDlogfile" #if CF doesn't use default URI, add --uri custom_uri (e.g --uri radio://0/80/2M/E7E7E7E70B)
+            #         # downloadSD= Popen(command, shell=True, stderr=STDOUT, stdout=f, text=True,         #download the log file in ....../ros2_ws/results/test_xxxxxxx/
+            #         #                     cwd= ros2_ws / "infinite_flight_results" ,start_new_session=True, executable="/bin/bash") 
+            #         # atexit.register(clean_process, downloadSD)
+            #         # downloadSD.wait(timeout=180)
+            #         f.write('success')
+            #         print("download successful")
+            #         os._exit(0)  
+            #         #we need to call _exit to finish the whole script because sys.exit only finishes this thread
+            #         #but _exit doesn't call cleanup handlers, flush stdio buffers, etc. Is this an issue ?
                     
-                except TimeoutExpired:
-                    # clean_process(downloadSD)
-                    print("Downloading SD card data was killed for taking too long")
-                    f.write('\n \n \n#########################################################\n')
-                    f.write("Downloading SD card data was killed for taking too long !\n")
-                    f.write('#########################################################\n \n \n \n')
-                    exit(1)
+                    
+            #     except TimeoutExpired:
+            #         # clean_process(downloadSD)
+            #         print("Downloading SD card data was killed for taking too long")
+            #         f.write('\n \n \n#########################################################\n')
+            #         f.write("Downloading SD card data was killed for taking too long !\n")
+            #         f.write('#########################################################\n \n \n \n')
+            #         os._exit(1)
                      
         else:
             print("all good")
-            # return False
             
 def clean_process(process:Popen) -> int :
     '''Kills process and its children on exit if they aren't already terminated (called with atexit). Returns 0 on termination, 1 if SIGKILL was needed''' 
@@ -88,7 +92,6 @@ def clean_process(process:Popen) -> int :
 
 
 def main():
-    
     #delete previous logfiles if they exist
     # if(Path(Path.home() / ".ros/log").exists()): #delete log files of the previous test
         # shutil.rmtree(Path.home() / ".ros/log")
@@ -97,90 +100,88 @@ def main():
     if(Path(ros2_ws / "infinite_flight_results").exists()):
         shutil.rmtree(ros2_ws / "infinite_flight_results")  
     os.makedirs(ros2_ws / "infinite_flight_results")
-    
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     allcfs = swarm.allcfs
-    # print("here")
     check_crashed_thread = threading.Thread(target=is_crashed, args=(swarm,ros2_ws), daemon=True)
     check_crashed_thread.start()
-    # print("there")
-    # exit(0)
-
     traj1 = Trajectory()
     traj1.loadcsv(Path(__file__).parent / 'data/figure8.csv')
     
     #enable logging
     allcfs.setParam("usd.logging", 1)
-
+    print("before upload traj", time.time())
     TIMESCALE = 1.0
-    for cf in allcfs.crazyflies:
+    for cf in allcfs.crazyflies: #sometimes we get stuck at this for loop forever. Is it because upload_trajectory doesn't work properly ?
+        print(cf)
         cf.uploadTrajectory(0, 0, traj1)
     timeHelper.sleep(1)
+    print("upload traj finished", time.time())
 
     # pm_state : 0 = on battery  1 = charging  2 = charged  3 = low power  4 = shutdown
     flight_counter = 1
-
     while True:
-        print('takeoff')
-        allcfs.takeoff(targetHeight=1.0, duration=2.0)
-        timeHelper.sleep(2.5)
-        for cf in allcfs.crazyflies:
-            pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
-            cf.goTo(pos, 0, 2.0)
-        timeHelper.sleep(2.5)
+        print("true loop")
+        time.sleep(2)
+        # print('takeoff')
+        # allcfs.takeoff(targetHeight=1.0, duration=2.0)
+        # timeHelper.sleep(2.5)
+        # for cf in allcfs.crazyflies:
+        #     pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+        #     cf.goTo(pos, 0, 2.0)
+        # timeHelper.sleep(2.5)
 
-        # fly figure8 until battery is low
-        fig8_counter = 0
-        status = allcfs.crazyflies[0].get_status()
-        # while status['battery'] > 3.8:
-        while status['pm_state'] == 0:
-            fig8_counter += 1
-            print(f'starting figure8 number {fig8_counter} of flight number {flight_counter}')
-            allcfs.startTrajectory(0, timescale=TIMESCALE)
-            timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
-            status = allcfs.crazyflies[0].get_status()
-            print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
-            timeHelper.sleep(1)
+        # # fly figure8 until battery is low
+        # fig8_counter = 0
+        # status = allcfs.crazyflies[0].get_status()
+        # # while status['battery'] > 3.8:
+        # while status['pm_state'] == 0:
+        #     fig8_counter += 1
+        #     print(f'starting figure8 number {fig8_counter} of flight number {flight_counter}')
+        #     allcfs.startTrajectory(0, timescale=TIMESCALE)
+        #     timeHelper.sleep(traj1.duration * TIMESCALE + 2.0)
+        #     status = allcfs.crazyflies[0].get_status()
+        #     print(f'pm state : {status["pm_state"]}, battery left : {status["battery"]}')
+        #     timeHelper.sleep(1)
 
-        # not sure if useful
-        # check if pm = 3 just to be sure, if not abort test
-        if status['pm_state'] != 3:
-            print(f'power state is not 3 (low) but {status["pm_state"]}. Landing and aborting')
-            allcfs.land(targetHeight=0.06, duration=2.0)
-            timeHelper.sleep(3)
-            return 1
+        # # not sure if useful
+        # # check if pm = 3 just to be sure, if not abort test
+        # if status['pm_state'] != 3:
+        #     print(f'power state is not 3 (low) but {status["pm_state"]}. Landing and aborting')
+        #     allcfs.land(targetHeight=0.06, duration=2.0)
+        #     timeHelper.sleep(3)
+        #     return 1
 
-        # now that battery is low, we try to land on the pad and see if it's charging
-        allcfs.land(targetHeight=0.06, duration=2.0)
-        timeHelper.sleep(5)
-        status = allcfs.crazyflies[0].get_status()
+        # # now that battery is low, we try to land on the pad and see if it's charging
+        # allcfs.land(targetHeight=0.06, duration=2.0)
+        # timeHelper.sleep(5)
+        # status = allcfs.crazyflies[0].get_status()
 
-        # if not charging, take off and land back again until it charges
-        while status['pm_state'] != 1:
-            print('Not charging, retrying')
-            allcfs.takeoff(targetHeight=1.0, duration=2.0)
-            timeHelper.sleep(2.5)
-            for cf in allcfs.crazyflies:
-                pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
-            cf.goTo(pos, 0, 2.0)
-            timeHelper.sleep(2.5)
-            allcfs.land(targetHeight=0.06, duration=2.0)
-            timeHelper.sleep(5)
-            status = allcfs.crazyflies[0].get_status()
+        # # if not charging, take off and land back again until it charges
+        # while status['pm_state'] != 1:
+        #     print('Not charging, retrying')
+        #     allcfs.takeoff(targetHeight=1.0, duration=2.0)
+        #     timeHelper.sleep(2.5)
+        #     for cf in allcfs.crazyflies:
+        #         pos = np.array(cf.initialPosition) + np.array([0, 0, 1.0])
+        #     cf.goTo(pos, 0, 2.0)
+        #     timeHelper.sleep(2.5)
+        #     allcfs.land(targetHeight=0.06, duration=2.0)
+        #     timeHelper.sleep(5)
+        #     status = allcfs.crazyflies[0].get_status()
 
-        # now we wait until the crazyflie is charged
-        while status['battery'] < 3.78:
-        # while status['pm_state'] != 2:
-            print(f'Charging in progress, battery at {status["battery"]}V')
-            timeHelper.sleep(60)
-            status = allcfs.crazyflies[0].get_status()
-            # check if it's still charging ###not sure if this check is useful
-            if status['pm_state'] != 1:
-                print(f'charging interrupted, pm state : {status["pm_state"]}')
+        # # now we wait until the crazyflie is charged
+        # while status['battery'] < 3.78:
+        # # while status['pm_state'] != 2:
+        #     print(f'Charging in progress, battery at {status["battery"]}V')
+        #     timeHelper.sleep(60)
+        #     status = allcfs.crazyflies[0].get_status()
+        #     # check if it's still charging ###not sure if this check is useful
+        #     if status['pm_state'] != 1:
+        #         print(f'charging interrupted, pm state : {status["pm_state"]}')
 
-        print('Charging finished, time to fly again')
-        flight_counter += 1
+        # print('Charging finished, time to fly again')
+        # flight_counter += 1
 
 
 if __name__ == '__main__':

--- a/crazyflie_examples/setup.cfg
+++ b/crazyflie_examples/setup.cfg
@@ -8,3 +8,4 @@ console_scripts =
     cmd_full_state = crazyflie_examples.cmd_full_state:main
     set_param = crazyflie_examples.set_param:main
     swap = crazyflie_examples.swap:main
+    infinite_flight = crazyflie_examples.infinite_flight:main

--- a/crazyflie_examples/setup.cfg
+++ b/crazyflie_examples/setup.cfg
@@ -9,3 +9,4 @@ console_scripts =
     set_param = crazyflie_examples.set_param:main
     swap = crazyflie_examples.swap:main
     infinite_flight = crazyflie_examples.infinite_flight:main
+    infiflight_download = crazyflie_examples.infinite_flight_download:main

--- a/crazyflie_examples/setup.cfg
+++ b/crazyflie_examples/setup.cfg
@@ -9,4 +9,4 @@ console_scripts =
     set_param = crazyflie_examples.set_param:main
     swap = crazyflie_examples.swap:main
     infinite_flight = crazyflie_examples.infinite_flight:main
-    infiflight_download = crazyflie_examples.infinite_flight_download:main
+    infinite_flight_download = crazyflie_examples.infinite_flight_download:main

--- a/crazyflie_interfaces/CMakeLists.txt
+++ b/crazyflie_interfaces/CMakeLists.txt
@@ -39,6 +39,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/UploadTrajectory.srv"
   "srv/RemoveLogging.srv"
   "srv/AddLogging.srv"
+  "srv/DownloadUSD.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs 
   ADD_LINTER_TESTS
 )

--- a/crazyflie_interfaces/srv/DownloadUSD.srv
+++ b/crazyflie_interfaces/srv/DownloadUSD.srv
@@ -1,0 +1,4 @@
+string outputfile
+string uri
+bool verbose
+---

--- a/crazyflie_interfaces/srv/DownloadUSD.srv
+++ b/crazyflie_interfaces/srv/DownloadUSD.srv
@@ -1,4 +1,3 @@
 string outputfile
-string uri
 bool verbose
 ---

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 # from .visualizer import visNull
 
 
-from crazyflie_interfaces.msg import FullState, Position, TrajectoryPolynomialPiece, Status
+from crazyflie_interfaces.msg import FullState, Position, Status, TrajectoryPolynomialPiece
 from crazyflie_interfaces.srv import GoTo, Land,\
     NotifySetpointsStop, StartTrajectory, Takeoff, UploadTrajectory
 from geometry_msgs.msg import Point
@@ -136,7 +136,8 @@ class Crazyflie:
         self.setParamsService = node.create_client(
             SetParameters, '/crazyflie_server/set_parameters')
         self.setParamsService.wait_for_service()
-        self.statusSubscriber = node.create_subscription(Status, f'{self.prefix}/status', self.status_topic_callback, 10)
+        self.statusSubscriber = node.create_subscription(
+            Status, f'{self.prefix}/status', self.status_topic_callback, 10)
         self.status = {}
 
         # Query some settings
@@ -700,23 +701,30 @@ class Crazyflie:
     #     self.setParam('ring/solidRed', int(r * 255))
     #     self.setParam('ring/solidGreen', int(g * 255))
     #     self.setParam('ring/solidBlue', int(b * 255))
-        
+
     def status_topic_callback(self, msg):
-        """Callback method updating the status attribute every time 
-        a crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status """
+        """
+        Callback method updating the status attribute every time a 
+        crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status
         
-        self.status = {'id' : msg.header.frame_id, 'timestamp_sec': msg.header.stamp.sec, 
-                  'timestamp_nsec' : msg.header.stamp.nanosec, 'supervisor' : msg.supervisor_info,
-                  'battery' : msg.battery_voltage, 'pm_state' : msg.pm_state, 'rssi' : msg.rssi, 
-                  'num_rx_broadcast':msg.num_rx_broadcast, 'num_tx_broadcast' : msg.num_tx_broadcast,
-                  'num_rx_unicast':msg.num_rx_unicast, 'num_tx_unicast' : msg.num_tx_unicast}
+        """
+        self.status = {'id': msg.header.frame_id, 
+                       'timestamp_sec': msg.header.stamp.sec, 
+                       'timestamp_nsec': msg.header.stamp.nanosec, 
+                       'supervisor': msg.supervisor_info,
+                       'battery': msg.battery_voltage, 
+                       'pm_state' : msg.pm_state, 
+                       'rssi': msg.rssi, 
+                       'num_rx_broadcast':msg.num_rx_broadcast, 
+                       'num_tx_broadcast': msg.num_tx_broadcast,
+                       'num_rx_unicast':msg.num_rx_unicast, 
+                       'num_tx_unicast': msg.num_tx_unicast}
 
-    
     def get_status(self):
-        """Returns the status dictionary containing info about:   
-        frame id, timestamp, supervisor info, battery voltage, pm state, rssi, number of received or
-        transmitted broadcast or unicast messages. see crazyflie_interfaces/msg/Status for details"""
-
+        """Returns the status dictionary containing info about:
+        frame id, timestamp, supervisor info, battery voltage, pm state, rssi, nb of received or
+        transmitted broadcast or unicast messages. see crazyflie_interfaces/msg/Status for details
+        """
         # self.node.get_logger().info(f'Crazyflie.get_status() was called {self.status}')
         return self.status
 

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -703,9 +703,10 @@ class Crazyflie:
     #     self.setParam('ring/solidBlue', int(b * 255))
 
     def status_topic_callback(self, msg):
-        """
-        Callback method updating the status attribute every time a
-        crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status
+        """Callback for topic /cfXXX/status.
+
+        Update the status attribute every time a crazyflie_interfaces/msg/Status
+        message is published on the topic /cfXXX/status
 
         """
         self.status = {'id': msg.header.frame_id,
@@ -721,7 +722,9 @@ class Crazyflie:
                        'num_tx_unicast': msg.num_tx_unicast}
 
     def get_status(self):
-        """Returns the status dictionary containing info about:
+        """Return the status attribute.
+
+        Status is a dictionary containing:
         frame id, timestamp, supervisor info, battery voltage, pm state, rssi, nb of received or
         transmitted broadcast or unicast messages. see crazyflie_interfaces/msg/Status for details
         """

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -703,7 +703,7 @@ class Crazyflie:
     #     self.setParam('ring/solidBlue', int(b * 255))
 
     def status_topic_callback(self, msg):
-        """Callback for topic /cfXXX/status.
+        """Call back for topic /cfXXX/status.
 
         Update the status attribute every time a crazyflie_interfaces/msg/Status
         message is published on the topic /cfXXX/status

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 # from .visualizer import visNull
 
 
-from crazyflie_interfaces.msg import FullState, Position, TrajectoryPolynomialPiece
+from crazyflie_interfaces.msg import FullState, Position, TrajectoryPolynomialPiece, Status
 from crazyflie_interfaces.srv import GoTo, Land,\
     NotifySetpointsStop, StartTrajectory, Takeoff, UploadTrajectory
 from geometry_msgs.msg import Point
@@ -136,6 +136,8 @@ class Crazyflie:
         self.setParamsService = node.create_client(
             SetParameters, '/crazyflie_server/set_parameters')
         self.setParamsService.wait_for_service()
+        self.statusSubscriber = node.create_subscription(Status, f'{self.prefix}/status', self.listener_callback, 10)
+        self.status = {}
 
         # Query some settings
         getParamsService = node.create_client(GetParameters, '/crazyflie_server/get_parameters')
@@ -698,6 +700,26 @@ class Crazyflie:
     #     self.setParam('ring/solidRed', int(r * 255))
     #     self.setParam('ring/solidGreen', int(g * 255))
     #     self.setParam('ring/solidBlue', int(b * 255))
+        
+    def listener_callback(self, msg):
+        """Callback method updating the status attribute every time 
+        a crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status """
+        
+        self.status = {'id' : msg.header.frame_id, 'timestamp_sec': msg.header.stamp.sec, 
+                  'timestamp_nsec' : msg.header.stamp.nanosec, 'supervisor' : msg.supervisor_info,
+                  'battery' : msg.battery_voltage, 'pm_state' : msg.pm_state, 'rssi' : msg.rssi, 
+                  'num_rx_broadcast':msg.num_rx_broadcast, 'num_tx_broadcast' : msg.num_tx_broadcast,
+                  'num_rx_unicast':msg.num_rx_unicast, 'num_tx_unicast' : msg.num_tx_unicast}
+        self.node.get_logger().info(f' Callbacl status')
+
+    
+    def get_status(self):
+        """Returns the status dictionary containing info about:   
+        frame id, timestamp, supervisor info, battery voltage, pm state, rssi, number of received or
+        transmitted broadcast or unicast messages. see crazyflie_interfaces/msg/Status for details"""
+
+        self.node.get_logger().info(f'get_status() was called {self.status}')
+        return self.status
 
 
 class CrazyflieServer(rclpy.node.Node):

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -704,20 +704,20 @@ class Crazyflie:
 
     def status_topic_callback(self, msg):
         """
-        Callback method updating the status attribute every time a 
+        Callback method updating the status attribute every time a
         crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status
-        
+
         """
-        self.status = {'id': msg.header.frame_id, 
-                       'timestamp_sec': msg.header.stamp.sec, 
-                       'timestamp_nsec': msg.header.stamp.nanosec, 
+        self.status = {'id': msg.header.frame_id,
+                       'timestamp_sec': msg.header.stamp.sec,
+                       'timestamp_nsec': msg.header.stamp.nanosec,
                        'supervisor': msg.supervisor_info,
-                       'battery': msg.battery_voltage, 
-                       'pm_state' : msg.pm_state, 
-                       'rssi': msg.rssi, 
-                       'num_rx_broadcast':msg.num_rx_broadcast, 
+                       'battery': msg.battery_voltage,
+                       'pm_state': msg.pm_state,
+                       'rssi': msg.rssi,
+                       'num_rx_broadcast': msg.num_rx_broadcast,
                        'num_tx_broadcast': msg.num_tx_broadcast,
-                       'num_rx_unicast':msg.num_rx_unicast, 
+                       'num_rx_unicast': msg.num_rx_unicast,
                        'num_tx_unicast': msg.num_tx_unicast}
 
     def get_status(self):

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -705,12 +705,11 @@ class Crazyflie:
         """Callback method updating the status attribute every time 
         a crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status """
         
-        self.status = {'id' : msg.header.frame_id, 'timestamp_sec': msg.header.stamp.sec, 
-                  'timestamp_nsec' : msg.header.stamp.nanosec, 'supervisor' : msg.supervisor_info,
-                  'battery' : msg.battery_voltage, 'pm_state' : msg.pm_state, 'rssi' : msg.rssi, 
-                  'num_rx_broadcast':msg.num_rx_broadcast, 'num_tx_broadcast' : msg.num_tx_broadcast,
-                  'num_rx_unicast':msg.num_rx_unicast, 'num_tx_unicast' : msg.num_tx_unicast}
-        self.node.get_logger().info(f' Callbacl status')
+        # self.status = {'id' : msg.header.frame_id, 'timestamp_sec': msg.header.stamp.sec, 
+        #           'timestamp_nsec' : msg.header.stamp.nanosec, 'supervisor' : msg.supervisor_info,
+        #           'battery' : msg.battery_voltage, 'pm_state' : msg.pm_state, 'rssi' : msg.rssi, 
+        #           'num_rx_broadcast':msg.num_rx_broadcast, 'num_tx_broadcast' : msg.num_tx_broadcast,
+        #           'num_rx_unicast':msg.num_rx_unicast, 'num_tx_unicast' : msg.num_tx_unicast}
 
     
     def get_status(self):
@@ -718,7 +717,7 @@ class Crazyflie:
         frame id, timestamp, supervisor info, battery voltage, pm state, rssi, number of received or
         transmitted broadcast or unicast messages. see crazyflie_interfaces/msg/Status for details"""
 
-        self.node.get_logger().info(f'get_status() was called {self.status}')
+        # self.node.get_logger().info(f'Crazyflie.get_status() was called {self.status}')
         return self.status
 
 
@@ -998,3 +997,16 @@ class CrazyflieServer(rclpy.node.Node):
         self.cmdFullStateMsg.twist.angular.y = omega[1]
         self.cmdFullStateMsg.twist.angular.z = omega[2]
         self.cmdFullStatePublisher.publish(self.cmdFullStateMsg)
+
+    def get_statuses(self):
+        '''
+        Obtain a list containing the status of each crazyflie controlled by the Crazyserver
+        Each status is a dict, see listener_callback() for more details
+        '''
+        
+        # self.get_logger().info(f'Crazyserver.get_statuses() was called')
+        statuses = []
+        for cf in self.crazyflies:
+            statuses.append(cf.get_status())
+            
+        return statuses

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -997,16 +997,3 @@ class CrazyflieServer(rclpy.node.Node):
         self.cmdFullStateMsg.twist.angular.y = omega[1]
         self.cmdFullStateMsg.twist.angular.z = omega[2]
         self.cmdFullStatePublisher.publish(self.cmdFullStateMsg)
-
-    def get_statuses(self):
-        '''
-        Obtain a list containing the status of each crazyflie controlled by the Crazyserver
-        Each status is a dict, see status_topic_callback() for more details
-        '''
-        
-        # self.get_logger().info(f'Crazyserver.get_statuses() was called')
-        statuses = []
-        for cf in self.crazyflies:
-            statuses.append(cf.get_status())
-            
-        return statuses

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -136,7 +136,7 @@ class Crazyflie:
         self.setParamsService = node.create_client(
             SetParameters, '/crazyflie_server/set_parameters')
         self.setParamsService.wait_for_service()
-        self.statusSubscriber = node.create_subscription(Status, f'{self.prefix}/status', self.listener_callback, 10)
+        self.statusSubscriber = node.create_subscription(Status, f'{self.prefix}/status', self.status_topic_callback, 10)
         self.status = {}
 
         # Query some settings
@@ -701,7 +701,7 @@ class Crazyflie:
     #     self.setParam('ring/solidGreen', int(g * 255))
     #     self.setParam('ring/solidBlue', int(b * 255))
         
-    def listener_callback(self, msg):
+    def status_topic_callback(self, msg):
         """Callback method updating the status attribute every time 
         a crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status """
         
@@ -1001,7 +1001,7 @@ class CrazyflieServer(rclpy.node.Node):
     def get_statuses(self):
         '''
         Obtain a list containing the status of each crazyflie controlled by the Crazyserver
-        Each status is a dict, see listener_callback() for more details
+        Each status is a dict, see status_topic_callback() for more details
         '''
         
         # self.get_logger().info(f'Crazyserver.get_statuses() was called')

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -705,11 +705,11 @@ class Crazyflie:
         """Callback method updating the status attribute every time 
         a crazyflie_interfaces/msg/Status message is published on the topic /cfXXX/status """
         
-        # self.status = {'id' : msg.header.frame_id, 'timestamp_sec': msg.header.stamp.sec, 
-        #           'timestamp_nsec' : msg.header.stamp.nanosec, 'supervisor' : msg.supervisor_info,
-        #           'battery' : msg.battery_voltage, 'pm_state' : msg.pm_state, 'rssi' : msg.rssi, 
-        #           'num_rx_broadcast':msg.num_rx_broadcast, 'num_tx_broadcast' : msg.num_tx_broadcast,
-        #           'num_rx_unicast':msg.num_rx_unicast, 'num_tx_unicast' : msg.num_tx_unicast}
+        self.status = {'id' : msg.header.frame_id, 'timestamp_sec': msg.header.stamp.sec, 
+                  'timestamp_nsec' : msg.header.stamp.nanosec, 'supervisor' : msg.supervisor_info,
+                  'battery' : msg.battery_voltage, 'pm_state' : msg.pm_state, 'rssi' : msg.rssi, 
+                  'num_rx_broadcast':msg.num_rx_broadcast, 'num_tx_broadcast' : msg.num_tx_broadcast,
+                  'num_rx_unicast':msg.num_rx_unicast, 'num_tx_unicast' : msg.num_tx_unicast}
 
     
     def get_status(self):

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -703,11 +703,11 @@ class Crazyflie:
     #     self.setParam('ring/solidBlue', int(b * 255))
 
     def status_topic_callback(self, msg):
-        """Call back for topic /cfXXX/status.
+        """
+        Call back for topic /cfXXX/status.
 
         Update the status attribute every time a crazyflie_interfaces/msg/Status
         message is published on the topic /cfXXX/status
-
         """
         self.status = {'id': msg.header.frame_id,
                        'timestamp_sec': msg.header.stamp.sec,
@@ -722,7 +722,8 @@ class Crazyflie:
                        'num_tx_unicast': msg.num_tx_unicast}
 
     def get_status(self):
-        """Return the status attribute.
+        """
+        Return the status attribute.
 
         Status is a dictionary containing:
         frame id, timestamp, supervisor info, battery voltage, pm state, rssi, nb of received or

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -742,18 +742,17 @@ class Crazyflie:
         req.outputfile = outputfile
         # req.uri = uri
         req.verbose = verbose
-        future = self.downloadUSDService.call_async(req)   #when I comment this I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 113, in call_async raise TypeError()
         self.node.get_logger().info(f'Crazyflie.downloadUSD was called with args {outputfile}, {verbose}')
+
+        future = self.downloadUSDService.call_async(req)   #with this line I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 711, in wait_for_ready_callbacks   return next(self._cb_iter)    ValueError: generator already executing
+        # future = self.setParamsService.call_async(req)   #with this line I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 113, in call_async raise TypeError()
+        
+        rclpy.spin_until_future_complete(self.node, future)
+        
         # while rclpy.ok():
         #     rclpy.spin_once(self.node)
         #     if future.done():
         #         break
-
-        future = self.downloadUSDService.call_async(req)   #with this line I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 711, in wait_for_ready_callbacks   return next(self._cb_iter)    ValueError: generator already executing
-        # future = self.setParamsService.call_async(req)   #with this line I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 113, in call_async raise TypeError()
-        rclpy.spin_until_future_complete(self.node, future)
-        
-        rclpy.spin_until_future_complete(self.node, future)
 
 
 

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -140,7 +140,7 @@ class Crazyflie:
             Status, f'{self.prefix}/status', self.status_topic_callback, 10)
         self.status = {}
         self.downloadUSDService = node.create_client(
-            DownloadUSD, prefix + '/downloadUSD')
+            DownloadUSD, prefix + '/download_usd')
         self.downloadUSDService.wait_for_service()
 
         # Query some settings
@@ -735,18 +735,25 @@ class Crazyflie:
         # self.node.get_logger().info(f'Crazyflie.get_status() was called {self.status}')
         return self.status
     
-    def downloadUSD(self, outputfile, uri="radio://0/80/2M/E7E7E7E7E7", verbose=False):
+    # def downloadUSD(self, outputfile, uri="radio://0/80/2M/E7E7E7E7E7", verbose=False):
+    def downloadUSD(self, outputfile, verbose=False):
 
         req = DownloadUSD.Request()
         req.outputfile = outputfile
-        req.uri = uri
+        # req.uri = uri
         req.verbose = verbose
-        future = self.downloadUSDService.call_async(req)
-        self.node.get_logger().info(f'Crazyflie.downloadUSD was called with args {outputfile}, {uri}, {verbose}')
-        while rclpy.ok():
-            rclpy.spin_once(self.node)
-            if future.done():
-                break
+        future = self.downloadUSDService.call_async(req)   #when I comment this I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 113, in call_async raise TypeError()
+        self.node.get_logger().info(f'Crazyflie.downloadUSD was called with args {outputfile}, {verbose}')
+        # while rclpy.ok():
+        #     rclpy.spin_once(self.node)
+        #     if future.done():
+        #         break
+
+        future = self.downloadUSDService.call_async(req)   #with this line I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 711, in wait_for_ready_callbacks   return next(self._cb_iter)    ValueError: generator already executing
+        # future = self.setParamsService.call_async(req)   #with this line I get : File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 113, in call_async raise TypeError()
+        rclpy.spin_until_future_complete(self.node, future)
+        
+        rclpy.spin_until_future_complete(self.node, future)
 
 
 


### PR DESCRIPTION
Trying to add the "download SD over radio" feature directly to the python layer so that it can be called while crazyserver is running (instead of having to shut down crazyserver to free the radio for the download), allowing it to be integrated in the middle of a crazyflie_example script for example. This is still work in progress

- created the "infinite_flight_download" example script in addition to infinite_flight as a wip. When it all works I plan to copy the code to infinite_flight and delete infinite_flight_download
- added the relevant functions to create the downloadUSD service to crazyflie.py and crazyflie_server.cpp, as well as the crazyflie interface file downloadUSD.srv

Problems :
1. Main problem : The typical way we use to call the service in crazyflie.py (a while loop of rcly.spin_once until future.done() == True) doesn't seem to work. Neither does the rclpy.spin_until_future_complete(). Both produce the same error "File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 711, in wait_for_ready_callbacks           return next(self._cb_iter)
ValueError: generator already executing"

2. Secondary problem : sometimes the script stays blocked in main() at the "cf.uploadTrajectory(0, 0, traj1)" line. The is_crashed thread runs, but the trajectory is never uploaded (which means the cf doesn't fly).
