### PR TITLE
remove tmp yaml files generated for server and motion capture. Add motion capture yaml import feature.

### DIFF
--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -22,10 +22,9 @@ def parse_yaml(context):
 
     with open(server_yaml, 'r') as ymlfile:
         server_yaml_content = yaml.safe_load(ymlfile)
-
-    server_yaml_content["/crazyflie_server"]["ros__parameters"]['robots'] = crazyflies['robots']
-    server_yaml_content["/crazyflie_server"]["ros__parameters"]['robot_types'] = crazyflies['robot_types']
-    server_yaml_content["/crazyflie_server"]["ros__parameters"]['all'] = crazyflies['all']
+    server_yaml_content['/crazyflie_server']['ros__parameters']['robots'] = crazyflies['robots']
+    server_yaml_content['/crazyflie_server']['ros__parameters']['robot_types'] = crazyflies['robot_types']
+    server_yaml_content['/crazyflie_server']['ros__parameters']['all'] = crazyflies['all']
 
     # robot description
     urdf = os.path.join(
@@ -36,7 +35,7 @@ def parse_yaml(context):
     with open(urdf, 'r') as f:
         robot_desc = f.read()
 
-    server_yaml_content["/crazyflie_server"]["ros__parameters"]["robot_description"] = robot_desc
+    server_yaml_content['/crazyflie_server']['ros__parameters']['robot_description'] = robot_desc
 
     # construct motion_capture_configuration
     motion_capture_yaml = os.path.join(
@@ -46,27 +45,27 @@ def parse_yaml(context):
     with open(motion_capture_yaml, 'r') as ymlfile:
         motion_capture_content = yaml.safe_load(ymlfile)
 
-    motion_capture_content["/motion_capture_tracking"]["ros__parameters"]["rigid_bodies"] = dict()
-    for key, value in crazyflies["robots"].items():
-        type = crazyflies["robot_types"][value["type"]]
-        if value["enabled"] and type["motion_capture"]["enabled"]:
-            motion_capture_content["/motion_capture_tracking"]["ros__parameters"]["rigid_bodies"][key] =  {
-                    "initial_position": value["initial_position"],
-                    "marker": type["motion_capture"]["marker"],
-                    "dynamics": type["motion_capture"]["dynamics"],
+    motion_capture_content['/motion_capture_tracking']['ros__parameters']['rigid_bodies'] = dict()
+    for key, value in crazyflies['robots'].items():
+        type = crazyflies['robot_types'][value['type']]
+        if value['enabled'] and type['motion_capture']['enabled']:
+            motion_capture_content['/motion_capture_tracking']['ros__parameters']['rigid_bodies'][key] =  {
+                    'initial_position': value['initial_position'],
+                    'marker': type['motion_capture']['marker'],
+                    'dynamics': type['motion_capture']['dynamics'],
                 }
 
     # copy relevent settings to server params
-    server_yaml_content["/crazyflie_server"]["ros__parameters"]["poses_qos_deadline"] = motion_capture_content[
-        "/motion_capture_tracking"]["ros__parameters"]["topics"]["poses"]["qos"]["deadline"]
-
+    server_yaml_content['/crazyflie_server']['ros__parameters']['poses_qos_deadline'] = motion_capture_content[
+        '/motion_capture_tracking']['ros__parameters']['topics']['poses']['qos']['deadline']
+    
     # Save server and mocap in temp file such that nodes can read it out later
     with open('tmp_server.yaml', 'w') as outfile:
         yaml.dump(server_yaml_content, outfile, default_flow_style=False, sort_keys=False)
 
     with open('tmp_motion_capture.yaml', 'w') as outfile:
         yaml.dump(motion_capture_content, outfile, default_flow_style=False, sort_keys=False)
-
+    
 
 def generate_launch_description():
     default_crazyflies_yaml_path = os.path.join(

--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -10,8 +10,8 @@ from launch.substitutions import LaunchConfiguration, PythonExpression
 
 def parse_yaml(context):
     # Load the crazyflies YAML file
-    crazyflies_yaml_file = LaunchConfiguration('crazyflies_yaml_file').perform(context)
-    with open(crazyflies_yaml_file, 'r') as file:
+    crazyflies_yaml = LaunchConfiguration('crazyflies_yaml_file').perform(context)
+    with open(crazyflies_yaml, 'r') as file:
         crazyflies = yaml.safe_load(file)
 
     # server params
@@ -36,11 +36,7 @@ def parse_yaml(context):
     server_params[1]['robot_description'] = robot_desc
 
     # construct motion_capture_configuration
-    motion_capture_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'motion_capture.yaml')
-    
+    motion_capture_yaml = LaunchConfiguration('motion_capture_yaml_file').perform(context)
     with open(motion_capture_yaml, 'r') as ymlfile:
         motion_capture_content = yaml.safe_load(ymlfile)
 
@@ -99,6 +95,11 @@ def generate_launch_description():
         get_package_share_directory('crazyflie'),
         'config',
         'crazyflies.yaml')
+    
+    default_motion_capture_yaml_path = os.path.join(
+        get_package_share_directory('crazyflie'),
+        'config',
+        'motion_capture.yaml')
 
     telop_yaml_path = os.path.join(
         get_package_share_directory('crazyflie'),
@@ -108,6 +109,8 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument('crazyflies_yaml_file', 
                               default_value=default_crazyflies_yaml_path),
+        DeclareLaunchArgument('motion_capture_yaml_file', 
+                              default_value=default_motion_capture_yaml_path),
         DeclareLaunchArgument('backend', default_value='cpp'),
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),


### PR DESCRIPTION
Fix for https://github.com/IMRCLab/crazyswarm2/issues/536. Most of the changes are switching from " to ' to be more consistent. To remove the temp files we can just pass the parameters directly from line [62-63](https://github.com/IMRCLab/crazyswarm2/compare/main...llanesc:pr-remove-tmp-yaml?expand=1#diff-17bbfc3a6e6f546112e95dcec6fcb9a07aa4ea3469a15931c1839fc32d3fb948R62).