### PR TITLE
Add teleop parameter for server launch file

### DIFF
--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -115,11 +115,12 @@ def generate_launch_description():
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),
         DeclareLaunchArgument('gui', default_value='True'),
-        DeclareLaunchArgument('teleop', default_value='False'),
+        DeclareLaunchArgument('teleop', default_value='True'),
         DeclareLaunchArgument('mocap', default_value='True'),
         DeclareLaunchArgument('teleop_yaml_file', default_value=''),
         OpaqueFunction(function=parse_yaml),
         Node(
+            condition=LaunchConfigurationEquals('teleop', 'True'),
             package='crazyflie',
             executable='teleop',
             name='teleop',

--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -115,6 +115,7 @@ def generate_launch_description():
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),
         DeclareLaunchArgument('gui', default_value='True'),
+        DeclareLaunchArgument('teleop', default_value='False'),
         DeclareLaunchArgument('mocap', default_value='True'),
         DeclareLaunchArgument('teleop_yaml_file', default_value=''),
         OpaqueFunction(function=parse_yaml),
@@ -135,6 +136,7 @@ def generate_launch_description():
             parameters= [PythonExpression(["'" + telop_yaml_path +"' if '", LaunchConfiguration('teleop_yaml_file'), "' == '' else '", LaunchConfiguration('teleop_yaml_file'), "'"])],
         ),
         Node(
+            condition=LaunchConfigurationEquals('teleop', 'True'),
             package='joy',
             executable='joy_node',
             name='joy_node' # by default id=0


### PR DESCRIPTION
Add a teleop parameter that enables the joy node. In reality this is no longer used that often though, so that is why the default is off.

fixes #67