### PR TITLE
Update odom transform to include crazyflie name

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -571,7 +571,7 @@ class CrazyflieServer(Node):
 
         t_base = TransformStamped()
         t_base.header.stamp = self.get_clock().now().to_msg()
-        t_base.header.frame_id = 'odom'
+        t_base.header.frame_id = cf_name +'/odom'
         t_base.child_frame_id = cf_name
         t_base.transform.translation.x = x
         t_base.transform.translation.y = y

--- a/crazyflie/scripts/simple_mapper_multiranger.py
+++ b/crazyflie/scripts/simple_mapper_multiranger.py
@@ -47,7 +47,7 @@ class SimpleMapperMultiranger(Node):
         t_map = TransformStamped()
         t_map.header.stamp = self.get_clock().now().to_msg()
         t_map.header.frame_id = 'map'
-        t_map.child_frame_id = 'odom'
+        t_map.child_frame_id = robot_prefix + '/odom'
         t_map.transform.translation.x = 0.0
         t_map.transform.translation.y = 0.0
         t_map.transform.translation.z = 0.0

--- a/crazyflie_examples/config/nav2_params.yaml
+++ b/crazyflie_examples/config/nav2_params.yaml
@@ -100,7 +100,7 @@ local_costmap:
     ros__parameters:
       update_frequency: 5.0
       publish_frequency: 2.0
-      global_frame: odom
+      global_frame: cf1/odom
       robot_base_frame: cf1
       use_sim_time: true
       rolling_window: true

--- a/crazyflie_examples/launch/multiranger_mapping_launch.py
+++ b/crazyflie_examples/launch/multiranger_mapping_launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         ),
         Node(
             parameters=[
-                {'odom_frame': 'odom'},
+                {'odom_frame': 'cf231/odom'},
                 {'map_frame': 'map'},
                 {'base_frame': 'cf231'},
                 {'scan_topic': '/cf231/scan'},


### PR DESCRIPTION
So I found a convention issue with the transform for odometry. Namely it should include the crazyflie name since odometry is platform specific. This is to enable more crazyflies as well.