### PR TITLE
Fix parameter seperation issues cflib server

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -107,7 +107,7 @@ class CrazyflieServer(Node):
                                 "odom": self._log_odom_data_callback,
                                 "status": self._log_status_data_callback}
 
-        self.world_tf_name = "world"
+        self.world_tf_name = "map"
         try:
             self.world_tf_name = self._ros_parameters["world_tf_name"]
         except KeyError:

--- a/crazyflie_examples/launch/keyboard_velmux_launch.py
+++ b/crazyflie_examples/launch/keyboard_velmux_launch.py
@@ -3,38 +3,22 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-import yaml
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 
 def generate_launch_description():
-    # load crazyflies
-    crazyflies_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'crazyflies.yaml')
 
-    with open(crazyflies_yaml, 'r') as ymlfile:
-        crazyflies = yaml.safe_load(ymlfile)
-
-    server_params = crazyflies
-
-    # robot description
-    urdf = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'urdf',
-        'crazyflie_description.urdf')
-    with open(urdf, 'r') as f:
-        robot_desc = f.read()
-    server_params['robot_description'] = robot_desc
+    crazyflie = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('crazyflie'), 'launch'),
+            '/launch.py']),
+        launch_arguments={
+            'backend': 'cflib',
+            }.items())
 
     return LaunchDescription([
-        Node(
-            package='crazyflie',
-            executable='crazyflie_server.py',
-            name='crazyflie_server',
-            output='screen',
-            parameters=[server_params]
-        ),
+        crazyflie,
         Node(
             package='crazyflie',
             executable='vel_mux.py',

--- a/crazyflie_examples/launch/keyboard_velmux_launch.py
+++ b/crazyflie_examples/launch/keyboard_velmux_launch.py
@@ -2,9 +2,9 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
 
 
 def generate_launch_description():

--- a/crazyflie_examples/launch/keyboard_velmux_launch.py
+++ b/crazyflie_examples/launch/keyboard_velmux_launch.py
@@ -15,6 +15,9 @@ def generate_launch_description():
             '/launch.py']),
         launch_arguments={
             'backend': 'cflib',
+            'gui': 'false',
+            'teleop': 'false',
+            'mocap': 'false',
             }.items())
 
     return LaunchDescription([

--- a/crazyflie_examples/launch/multiranger_mapping_launch.py
+++ b/crazyflie_examples/launch/multiranger_mapping_launch.py
@@ -2,9 +2,9 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
 
 
 def generate_launch_description():

--- a/crazyflie_examples/launch/multiranger_mapping_launch.py
+++ b/crazyflie_examples/launch/multiranger_mapping_launch.py
@@ -15,6 +15,9 @@ def generate_launch_description():
             '/launch.py']),
         launch_arguments={
             'backend': 'cflib',
+            'gui': 'false',
+            'teleop': 'false',
+            'mocap': 'false',
             }.items())
 
     return LaunchDescription([

--- a/crazyflie_examples/launch/multiranger_mapping_launch.py
+++ b/crazyflie_examples/launch/multiranger_mapping_launch.py
@@ -3,38 +3,22 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-import yaml
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 
 def generate_launch_description():
-    # load crazyflies
-    crazyflies_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'crazyflies.yaml')
 
-    with open(crazyflies_yaml, 'r') as ymlfile:
-        crazyflies = yaml.safe_load(ymlfile)
-
-    server_params = crazyflies
-
-    # robot description
-    urdf = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'urdf',
-        'crazyflie_description.urdf')
-    with open(urdf, 'r') as f:
-        robot_desc = f.read()
-    server_params['robot_description'] = robot_desc
+    crazyflie = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('crazyflie'), 'launch'),
+            '/launch.py']),
+        launch_arguments={
+            'backend': 'cflib',
+            }.items())
 
     return LaunchDescription([
-        Node(
-            package='crazyflie',
-            executable='crazyflie_server.py',
-            name='crazyflie_server',
-            output='screen',
-            parameters=[server_params],
-        ),
+        crazyflie,
         Node(
             package='crazyflie',
             executable='vel_mux.py',

--- a/crazyflie_examples/launch/multiranger_nav2_launch.py
+++ b/crazyflie_examples/launch/multiranger_nav2_launch.py
@@ -15,7 +15,9 @@ def generate_launch_description():
             '/launch.py']),
         launch_arguments={
             'backend': 'cflib',
-            'world_tf_name': 'map',
+            'gui': 'false',
+            'teleop': 'false',
+            'mocap': 'false',
             }.items())
 
     cf_examples_dir = get_package_share_directory('crazyflie_examples')

--- a/crazyflie_examples/launch/multiranger_nav2_launch.py
+++ b/crazyflie_examples/launch/multiranger_nav2_launch.py
@@ -5,29 +5,18 @@ from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-import yaml
 
 
 def generate_launch_description():
-    # load crazyflies
-    crazyflies_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'crazyflies.yaml')
 
-    with open(crazyflies_yaml, 'r') as ymlfile:
-        crazyflies = yaml.safe_load(ymlfile)
-
-    server_params = crazyflies
-
-    # robot description
-    urdf = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'urdf',
-        'crazyflie_description.urdf')
-    with open(urdf, 'r') as f:
-        robot_desc = f.read()
-    server_params['robot_description'] = robot_desc
+    crazyflie = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('crazyflie'), 'launch'),
+            '/launch.py']),
+        launch_arguments={
+            'backend': 'cflib',
+            'world_tf_name': 'map',
+            }.items())
 
     cf_examples_dir = get_package_share_directory('crazyflie_examples')
     bringup_dir = get_package_share_directory('nav2_bringup')
@@ -35,14 +24,8 @@ def generate_launch_description():
     map_name = 'map'
 
     return LaunchDescription([
-        Node(
-            package='crazyflie',
-            executable='crazyflie_server.py',
-            name='crazyflie_server',
-            output='screen',
-            parameters=[{'world_tf_name': 'map'},
-                        server_params],
-        ),
+
+        crazyflie,
         Node(
             package='crazyflie',
             executable='vel_mux.py',

--- a/crazyflie_examples/launch/multiranger_simple_mapper_launch.py
+++ b/crazyflie_examples/launch/multiranger_simple_mapper_launch.py
@@ -15,6 +15,9 @@ def generate_launch_description():
             '/launch.py']),
         launch_arguments={
             'backend': 'cflib',
+            'gui': 'false',
+            'teleop': 'false',
+            'mocap': 'false',
             }.items())
 
     crazyflie_name = '/cf231'

--- a/crazyflie_examples/launch/multiranger_simple_mapper_launch.py
+++ b/crazyflie_examples/launch/multiranger_simple_mapper_launch.py
@@ -3,34 +3,24 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
-import yaml
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 
 def generate_launch_description():
 
-    # load crazyflies
-    crazyflies_yaml = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'config',
-        'crazyflies.yaml')
-
-    with open(crazyflies_yaml, 'r') as ymlfile:
-        crazyflies = yaml.safe_load(ymlfile)
-
-    server_params = crazyflies
-
-    # robot description
-    urdf = os.path.join(
-        get_package_share_directory('crazyflie'),
-        'urdf',
-        'crazyflie_description.urdf')
-    with open(urdf, 'r') as f:
-        robot_desc = f.read()
-    server_params['robot_description'] = robot_desc
+    crazyflie = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('crazyflie'), 'launch'),
+            '/launch.py']),
+        launch_arguments={
+            'backend': 'cflib',
+            }.items())
 
     crazyflie_name = '/cf231'
 
     return LaunchDescription([
+        crazyflie,
         Node(
             package='crazyflie',
             executable='crazyflie_server.py',

--- a/crazyflie_examples/launch/multiranger_simple_mapper_launch.py
+++ b/crazyflie_examples/launch/multiranger_simple_mapper_launch.py
@@ -2,9 +2,9 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
 
 
 def generate_launch_description():
@@ -24,13 +24,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         crazyflie,
-        Node(
-            package='crazyflie',
-            executable='crazyflie_server.py',
-            name='crazyflie_server',
-            output='screen',
-            parameters=[server_params]
-        ),
         Node(
             package='crazyflie',
             executable='vel_mux.py',


### PR DESCRIPTION
All the crazyflie examples use the include launch description now such that I don't have to recreate the parameter handling everytime when something is changed.

 Should fix #571  