### PR TITLE
doc2 pyyaml install error fix

### DIFF
--- a/.github/workflows/ci-docs2.yml
+++ b/.github/workflows/ci-docs2.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt update
         sudo apt install texlive-latex-extra dvipng
         sudo pip3 install -U setuptools
-        sudo pip3 install -U -r docs2/requirements.txt
+        sudo pip3 install -U -r docs2/requirements.txt --ignore-installed PyYAML
 
     - name: Build Docs
       run: |

--- a/docs2/tutorials.rst
+++ b/docs2/tutorials.rst
@@ -215,6 +215,8 @@ Let's first look at the launch file real quick (multiranger_mapping_launch.py):
               }.items()
           ),
       ])
+
+      
 Here is an explanation of the nodes:
 
 * The first node enables the crazyflie server, namely the python version (cflib) as that currently has logging enabled. This takes the crazyflies.yaml file you just edited and uses those values to set up the crazyflie. You might need to change some topic strings based on your Crazyflie name (`/cf231` to something else)


### PR DESCRIPTION
pyyaml was giving issues which blocks the docs from being deployed. Apparently it doesn't like when pyyaml is already installed system wide but pip wants to install it again. 