### PR TITLE
- Add versioning of crazyflies.yaml

### DIFF
--- a/crazyflie/config/crazyflies.yaml
+++ b/crazyflie/config/crazyflies.yaml
@@ -1,4 +1,5 @@
 # named list of all robots
+fileversion: 2
 robots:
   cf231:
     enabled: true
@@ -31,7 +32,7 @@ robots:
 robot_types:
   cf21:
     motion_capture:
-      enabled: true
+      tracking: "librigidbodytracker" # one of "vendor", "librigidbodytracker"
       # only if enabled; see motion_capture.yaml
       marker: default_single_marker
       dynamics: default
@@ -54,7 +55,7 @@ robot_types:
 
   cf21_mocap_deck:
     motion_capture:
-      enabled: true
+      tracking: "librigidbodytracker" # one of "vendor", "librigidbodytracker"
       # only if enabled; see motion_capture.yaml
       marker: mocap_deck
       dynamics: default

--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -13,6 +13,10 @@ def parse_yaml(context):
     crazyflies_yaml = LaunchConfiguration('crazyflies_yaml_file').perform(context)
     with open(crazyflies_yaml, 'r') as file:
         crazyflies = yaml.safe_load(file)
+    # store the fileversion
+    fileversion = 1
+    if "fileversion" in crazyflies:
+        fileversion = crazyflies["fileversion"]
 
     # server params
     server_yaml = os.path.join(
@@ -44,7 +48,9 @@ def parse_yaml(context):
     motion_capture_params['rigid_bodies'] = dict()
     for key, value in crazyflies['robots'].items():
         type = crazyflies['robot_types'][value['type']]
-        if value['enabled'] and type['motion_capture']['enabled']:
+        if value['enabled'] and \
+            ((fileversion == 1 and type['motion_capture']['enabled']) or \
+            ((fileversion >= 2 and type['motion_capture']['tracking'] == "librigidbodytracker"))):
             motion_capture_params['rigid_bodies'][key] =  {
                     'initial_position': value['initial_position'],
                     'marker': type['motion_capture']['marker'],


### PR DESCRIPTION
- As example usage, clarify the semantics of  the "motion_capture"/"enabled" setting, which caused lots of confusion before

Fixes #222 and #223.