### PR TITLE
switch systemtests to use dedicated "threadripper" machine, which has…

### DIFF
--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: threadripper
     steps:
       - name: Create workspace
         id: step1

--- a/.github/workflows/systemtests_sim.yml
+++ b/.github/workflows/systemtests_sim.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: threadripper
     steps:
       - name: Build firmware
         id: step1


### PR DESCRIPTION
… all required software installed.

Currently, the tests might run on another machine (labeled "self-hosted"), that only has docker (on purpose), but no ROS etc. 
Longer term, we likely want to switch the simulation-based tests to use docker as well (and execute them on the github buildfarm, rather than our infrastructure).