### PR TITLE
Fool proof parameter set and get in crazyflie python library

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -767,6 +767,17 @@ class CrazyflieServer(Node):
                                 value=cf_param_value,
                                 descriptor=parameter_descriptor,
                                 )
+                            # Based on the parameters from the last Crazyflie, set params for all
+                            # Warning: if any of the other crazyflies have different paramters    this will result in an error
+                            try:
+                                self.declare_parameter(
+                                    "all.params." + group + "." + param,
+                                    value=cf_param_value,
+                                    descriptor=parameter_descriptor,
+                                    )
+                            except Exception as e:
+                                continue
+
 
         self.get_logger().info("All Crazyflies parameters are initialized.")
 

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -768,7 +768,8 @@ class CrazyflieServer(Node):
                                 descriptor=parameter_descriptor,
                                 )
                             # Based on the parameters from the last Crazyflie, set params for all
-                            # Warning: if any of the other crazyflies have different paramters    this will result in an error
+                            # Warning: if any of the other crazyflies have different parameters
+                            #                this will result in an error
                             try:
                                 self.declare_parameter(
                                     "all.params." + group + "." + param,

--- a/crazyflie_examples/crazyflie_examples/set_param.py
+++ b/crazyflie_examples/crazyflie_examples/set_param.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 
 from crazyflie_py import Crazyswarm
-import time
 
 def main():
-    # allow some time for the Crazyflies to connect and setup parameters
-    time.sleep(22.0)  # wait for the Crazyflies to connect
+    # In case of key errors, wait for all the crazyflies to be fully connected
+    # before running the script. 
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     allcfs = swarm.allcfs

--- a/crazyflie_examples/crazyflie_examples/set_param.py
+++ b/crazyflie_examples/crazyflie_examples/set_param.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
 from crazyflie_py import Crazyswarm
-
+import time
 
 def main():
+    # allow some time for the Crazyflies to connect and setup parameters
+    time.sleep(22.0)  # wait for the Crazyflies to connect
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     allcfs = swarm.allcfs
-    timeHelper.sleep(5.0)
 
     # disable LED (one by one)
     for cf in allcfs.crazyflies:

--- a/crazyflie_examples/crazyflie_examples/set_param.py
+++ b/crazyflie_examples/crazyflie_examples/set_param.py
@@ -2,9 +2,10 @@
 
 from crazyflie_py import Crazyswarm
 
+
 def main():
     # In case of key errors, wait for all the crazyflies to be fully connected
-    # before running the script. 
+    # before running the script.
     # Also 'query_all_values_on_connect' should be set to True in the server.yaml file.
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper

--- a/crazyflie_examples/crazyflie_examples/set_param.py
+++ b/crazyflie_examples/crazyflie_examples/set_param.py
@@ -5,6 +5,7 @@ from crazyflie_py import Crazyswarm
 def main():
     # In case of key errors, wait for all the crazyflies to be fully connected
     # before running the script. 
+    # Also 'query_all_values_on_connect' should be set to True in the server.yaml file.
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     allcfs = swarm.allcfs

--- a/crazyflie_examples/crazyflie_examples/set_param.py
+++ b/crazyflie_examples/crazyflie_examples/set_param.py
@@ -7,13 +7,14 @@ def main():
     swarm = Crazyswarm()
     timeHelper = swarm.timeHelper
     allcfs = swarm.allcfs
+    timeHelper.sleep(5.0)
 
     # disable LED (one by one)
     for cf in allcfs.crazyflies:
         cf.setParam('led.bitmask', 128)
         timeHelper.sleep(1.0)
         if cf.getParam('led.bitmask') != 128:
-            print('LED of cf', cf.id, 'is not disabled!')
+            print('LED is not disabled!')
 
     timeHelper.sleep(2.0)
 

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -543,7 +543,6 @@ class Crazyflie:
             self.node.get_logger().warn(f'(crazyflie.py)getParam : exception raised {e}')
             return float('nan')
 
-
     def setParam(self, name, value):
         """
         Change the value of the given parameter.

--- a/crazyflie_py/crazyflie_py/crazyflie.py
+++ b/crazyflie_py/crazyflie_py/crazyflie.py
@@ -526,7 +526,6 @@ class Crazyflie:
         """
         try:
             param_name = self.prefix[1:] + '.params.' + name
-            self.node.get_logger().info(f'(crazyflie.py)getParam : trying to get {param_name}')
             req = GetParameters.Request()
             req.names = [param_name]
             future = self.getParamsService.call_async(req)


### PR DESCRIPTION
It doesn't solve issue #547 fully... but perhaps we need to close that one anyway since it would include a bigger feature or discussion, of how to indicate if all the crazyflies are fully connected. But I'd like to solve that separately as a bigger feature.

At least this foolproofs the crazyflie parameter setting and getting in the crazyflie_py and add some warnings to the script. If it needs to be run in a one line, someone would need to add a long sleep now before the swarm class is initialized (since that grabs all the parameters types). 

Moreover, cf.id didn't exist anymore so I've removed that now as well.