### PR TITLE
Add the custom reference frame support to cflib backend and rviz visualization sim backend

### DIFF
--- a/crazyflie/config/crazyflies.yaml
+++ b/crazyflie/config/crazyflies.yaml
@@ -1,5 +1,6 @@
 # named list of all robots
-fileversion: 2
+fileversion: 3
+
 robots:
   cf231:
     enabled: true
@@ -16,6 +17,7 @@ robots:
     #       frequency: 1
     #       vars: ["acc.x", "acc.y"]
     # reference_frame: "odom_cf231" # use a custom reference frame if no global coordinate system is available
+
   cf5:
     enabled: false
     uri: radio://0/80/2M/E7E7E7E705
@@ -29,6 +31,8 @@ robots:
     #    topic_name3: 
     #      frequency: 1
     #      vars: ["acc.x", "acc.y", "acc.z"]
+    # reference_frame: "odom_cf5" 
+
 # Definition of the various robot types
 robot_types:
   cf21:
@@ -53,7 +57,7 @@ robot_types:
     #    topic_name3: 
     #      frequency: 1
     #      vars: ["acc.x", "acc.y", "acc.z"]
-    # reference_frame: "odom_cf231" # use a custom reference frame if no global coordinate system is available
+    # reference_frame: "odom" 
 
   cf21_mocap_deck:
     motion_capture:
@@ -65,10 +69,19 @@ robot_types:
     battery:
       voltage_warning: 3.8  # V
       voltage_critical: 3.7 # V
-
     # firmware_params:
     #   kalman:
     #     pNAcc_xy: 1.0 # default 0.5
+    #firmware_logging:
+    #   enabled: true
+    #   default_topics:
+    #   pose:
+    #     frequency: 1 # Hz
+    #   custom_topics:
+    #    topic_name3: 
+    #      frequency: 1
+    #      vars: ["acc.x", "acc.y", "acc.z"]
+    # reference_frame: "mocap" 
 
 # global settings for all robots
 all:

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -109,11 +109,12 @@ class CrazyflieServer(Node):
                                 "status": self._log_status_data_callback}
 
         world_tf_name = "world"
+        robot_yaml_version = 0
+
         try:
             robot_yaml_version = self._ros_parameters["fileversion"]
         except KeyError:
             self.get_logger().info("No fileversion found in crazyflies.yaml, assuming version 0")
-            robot_yaml_version = 0
         
         # Check if the Crazyflie library is initialized
         robot_data = self._ros_parameters["robots"]

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -109,9 +109,11 @@ class CrazyflieServer(Node):
                                 "status": self._log_status_data_callback}
 
         world_tf_name = "world"
-        robot_yaml_version = self._ros_parameters["fileversion"]
-        if robot_yaml_version < 3:
-            world_tf_name = self._ros_parameters["world_tf_name"]
+        try:
+            robot_yaml_version = self._ros_parameters["fileversion"]
+        except KeyError:
+            self.get_logger().info("No fileversion found in crazyflies.yaml, assuming version 0")
+            robot_yaml_version = 0
         
         # Check if the Crazyflie library is initialized
         robot_data = self._ros_parameters["robots"]
@@ -682,7 +684,7 @@ class CrazyflieServer(Node):
 
         t_base = TransformStamped()
         t_base.header.stamp = self.get_clock().now().to_msg()
-        t_base.header.frame_id = cf_name +'/odom'
+        t_base.header.frame_id = self.swarm._cfs[uri].reference_frame
         t_base.child_frame_id = cf_name
         t_base.transform.translation.x = x
         t_base.transform.translation.y = y

--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -108,11 +108,12 @@ class CrazyflieServer(Node):
                                 "odom": self._log_odom_data_callback,
                                 "status": self._log_status_data_callback}
 
-        self.world_tf_name = "map"
-        try:
-            self.world_tf_name = self._ros_parameters["world_tf_name"]
-        except KeyError:
-            pass
+        world_tf_name = "world"
+        robot_yaml_version = self._ros_parameters["fileversion"]
+        if robot_yaml_version < 3:
+            world_tf_name = self._ros_parameters["world_tf_name"]
+        
+        # Check if the Crazyflie library is initialized
         robot_data = self._ros_parameters["robots"]
 
         # Init a transform broadcaster
@@ -236,6 +237,23 @@ class CrazyflieServer(Node):
                     self.swarm._cfs[link_uri].logging["custom_log_groups"][log_group_name]["vars"] = custom_log_topics[log_group_name]["vars"]
                     self.swarm._cfs[link_uri].logging["custom_log_groups"][log_group_name][
                         "frequency"] = custom_log_topics[log_group_name]["frequency"]
+
+            reference_frame = world_tf_name
+               # if larger then 3, then the reference frame is not set in the yaml file
+            if robot_yaml_version >= 3: 
+                try:
+                    reference_frame =self._ros_parameters['all']["reference_frame"]
+                except KeyError:
+                    pass
+                try:
+                    reference_frame =self._ros_parameters['robot_types'][robot_data[cf_name]['type']]["reference_frame"]
+                except KeyError:
+                    pass
+                try:
+                    reference_frame =self._ros_parameters['robots'][cf_name]["reference_frame"]
+                except KeyError:
+                    pass
+            self.swarm._cfs[link_uri].reference_frame = reference_frame
 
         # Now all crazyflies are initialized, open links!
         try:
@@ -587,7 +605,7 @@ class CrazyflieServer(Node):
 
         msg = PoseStamped()
         msg.header.stamp = self.get_clock().now().to_msg()
-        msg.header.frame_id = self.world_tf_name
+        msg.header.frame_id = self.swarm._cfs[uri].reference_frame
         msg.pose.position.x = x
         msg.pose.position.y = y
         msg.pose.position.z = z
@@ -603,7 +621,7 @@ class CrazyflieServer(Node):
 
         t_base = TransformStamped()
         t_base.header.stamp = self.get_clock().now().to_msg()
-        t_base.header.frame_id = self.world_tf_name
+        t_base.header.frame_id = self.swarm._cfs[uri].reference_frame
         t_base.child_frame_id = cf_name
         t_base.transform.translation.x = x
         t_base.transform.translation.y = y
@@ -641,7 +659,7 @@ class CrazyflieServer(Node):
         msg = Odometry()
         msg.child_frame_id = cf_name
         msg.header.stamp = self.get_clock().now().to_msg()
-        msg.header.frame_id = self.world_tf_name
+        msg.header.frame_id = self.swarm._cfs[uri].reference_frame
         msg.pose.pose.position.x = x
         msg.pose.pose.position.y = y
         msg.pose.pose.position.z = z
@@ -686,7 +704,7 @@ class CrazyflieServer(Node):
 
         msg = Status()
         msg.header.stamp = self.get_clock().now().to_msg()
-        msg.header.frame_id = self.world_tf_name
+        msg.header.frame_id = self.swarm._cfs[uri].reference_frame
 
         # From logging statistics
         msg.supervisor_info = data.get('supervisor.info')

--- a/crazyflie_sim/crazyflie_sim/crazyflie_server.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_server.py
@@ -78,9 +78,6 @@ class CrazyflieServer(Node):
                         reference_frame =self._ros_parameters['robots'][cfname]["reference_frame"]
                     except KeyError:
                         pass
-                    self.get_logger().info(
-                        f'[{cfname}] reference frame: {reference_frame}'
-                    )
                     reference_frames.append(reference_frame)
 
         # initialize backend by dynamically loading the module

--- a/crazyflie_sim/crazyflie_sim/crazyflie_server.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_server.py
@@ -67,7 +67,7 @@ class CrazyflieServer(Node):
                     initial_states.append(State(pos))
                     # Get the current reference frame for the robot
                     reference_frame = world_tf_name
-                    if self._ros_parameters.get('fileversion', 0) >= 3:
+                    if robot_yaml_version >= 3:
                         try:
                             reference_frame = self._ros_parameters['all']['reference_frame']
                         except KeyError:
@@ -78,7 +78,8 @@ class CrazyflieServer(Node):
                         except KeyError:
                             pass
                         try:
-                            reference_frame = self._ros_parameters['robots'][cfname]['reference_frame']
+                            reference_frame = self._ros_parameters['robots'][
+                                cfname]['reference_frame']
                         except KeyError:
                             pass
                     reference_frames.append(reference_frame)

--- a/crazyflie_sim/crazyflie_sim/crazyflie_server.py
+++ b/crazyflie_sim/crazyflie_sim/crazyflie_server.py
@@ -40,16 +40,20 @@ class CrazyflieServer(Node):
         self._ros_parameters = self._param_to_dict(self._parameters)
         self.cfs = {}
 
-        self.world_tf_name = 'world'
+        world_tf_name = 'world'
+        robot_yaml_version = 0
+
         try:
-            self.world_tf_name = self._ros_parameters['world_tf_name']
+            robot_yaml_version = self._ros_parameters["fileversion"]
         except KeyError:
-            pass
+            self.get_logger().info("No fileversion found in crazyflies.yaml, assuming version 0")
+
         robot_data = self._ros_parameters['robots']
 
         # Parse robots
         names = []
         initial_states = []
+        reference_frames = []
         for cfname in robot_data:
             if robot_data[cfname]['enabled']:
                 type_cf = robot_data[cfname]['type']
@@ -60,6 +64,24 @@ class CrazyflieServer(Node):
                     names.append(cfname)
                     pos = robot_data[cfname]['initial_position']
                     initial_states.append(State(pos))
+                # Get the current reference frame for the robot
+                    reference_frame = world_tf_name
+                    try:
+                        reference_frame =self._ros_parameters['all']["reference_frame"]
+                    except KeyError:
+                        pass
+                    try: 
+                        reference_frame =self._ros_parameters['robot_types'][robot_data[cfname]['type']]["reference_frame"]
+                    except KeyError:
+                        pass
+                    try:
+                        reference_frame =self._ros_parameters['robots'][cfname]["reference_frame"]
+                    except KeyError:
+                        pass
+                    self.get_logger().info(
+                        f'[{cfname}] reference frame: {reference_frame}'
+                    )
+                    reference_frames.append(reference_frame)
 
         # initialize backend by dynamically loading the module
         backend_name = self._ros_parameters['sim']['backend']
@@ -75,10 +97,18 @@ class CrazyflieServer(Node):
                                                  str(vis_key),
                                                  package='crazyflie_sim')
                 class_ = getattr(module, 'Visualization')
-                vis = class_(self,
-                             self._ros_parameters['sim']['visualizations'][vis_key],
-                             names,
-                             initial_states)
+                if vis_key == 'rviz':
+                    # special case for rviz, which needs the reference frames
+                    vis = class_(self,
+                                 self._ros_parameters['sim']['visualizations'][vis_key],
+                                 names,
+                                 initial_states,
+                                 reference_frames)
+                else:
+                    vis = class_(self,
+                                self._ros_parameters['sim']['visualizations'][vis_key],
+                                names,
+                                initial_states)
                 self.visualizations.append(vis)
 
         controller_name = backend_name = self._ros_parameters['sim']['controller']

--- a/crazyflie_sim/crazyflie_sim/visualization/rviz.py
+++ b/crazyflie_sim/crazyflie_sim/visualization/rviz.py
@@ -16,7 +16,6 @@ class Visualization:
         self.node = node
         self.names = names
         self.reference_frames = reference_frames 
-        print(f"Visualization: {self.names} with reference frames {self.reference_frames}")
         self.tfbr = TransformBroadcaster(self.node)
 
     def step(self, t, states: list[State], states_desired: list[State], actions: list[Action]):

--- a/crazyflie_sim/crazyflie_sim/visualization/rviz.py
+++ b/crazyflie_sim/crazyflie_sim/visualization/rviz.py
@@ -13,8 +13,13 @@ class Visualization:
     """Publishes ROS 2 transforms of the states, so that they can be visualized in RVIZ."""
 
     def __init__(
-        self, node: Node, params: dict, names: list[str], states: list[State], reference_frames: list[str]
-        ):
+        self,
+        node: Node,
+        params: dict,
+        names: list[str],
+        states: list[State],
+        reference_frames: list[str],
+    ):
         self.node = node
         self.names = names
         self.reference_frames = reference_frames

--- a/crazyflie_sim/crazyflie_sim/visualization/rviz.py
+++ b/crazyflie_sim/crazyflie_sim/visualization/rviz.py
@@ -12,19 +12,21 @@ from ..sim_data_types import Action, State
 class Visualization:
     """Publishes ROS 2 transforms of the states, so that they can be visualized in RVIZ."""
 
-    def __init__(self, node: Node, params: dict, names: list[str], states: list[State]):
+    def __init__(self, node: Node, params: dict, names: list[str], states: list[State], reference_frames: list[str]):
         self.node = node
         self.names = names
+        self.reference_frames = reference_frames 
+        print(f"Visualization: {self.names} with reference frames {self.reference_frames}")
         self.tfbr = TransformBroadcaster(self.node)
 
     def step(self, t, states: list[State], states_desired: list[State], actions: list[Action]):
         # publish transformation to visualize in rviz
         msgs = []
-        for name, state in zip(self.names, states):
+        for name, state, reference_frame in zip(self.names, states, self.reference_frames):
             msg = TransformStamped()
             msg.header.stamp.sec = math.floor(t)
             msg.header.stamp.nanosec = int((t - msg.header.stamp.sec) * 1e9)
-            msg.header.frame_id = 'world'
+            msg.header.frame_id = reference_frame
             msg.child_frame_id = name
             msg.transform.translation.x = state.pos[0]
             msg.transform.translation.y = state.pos[1]

--- a/crazyflie_sim/crazyflie_sim/visualization/rviz.py
+++ b/crazyflie_sim/crazyflie_sim/visualization/rviz.py
@@ -12,10 +12,12 @@ from ..sim_data_types import Action, State
 class Visualization:
     """Publishes ROS 2 transforms of the states, so that they can be visualized in RVIZ."""
 
-    def __init__(self, node: Node, params: dict, names: list[str], states: list[State], reference_frames: list[str]):
+    def __init__(
+        self, node: Node, params: dict, names: list[str], states: list[State], reference_frames: list[str]
+        ):
         self.node = node
         self.names = names
-        self.reference_frames = reference_frames 
+        self.reference_frames = reference_frames
         self.tfbr = TransformBroadcaster(self.node)
 
     def step(self, t, states: list[State], states_desired: list[State], actions: list[Action]):

--- a/docs2/tutorials.rst
+++ b/docs2/tutorials.rst
@@ -94,7 +94,7 @@ Mapping with simple mapper
 
 If you have a crazyflie with a multiranger and flowdeck, you can try out some simple mapping.
 
-Make sure that the scan and odometry logging is enabled in crazyflies.yaml:
+Make sure that the scan and odometry logging is enabled and the reference frame is set to odom in crazyflies.yaml:
 
 .. code-block:: bash
 
@@ -114,6 +114,12 @@ and make sure that the pid controller and kalman filter is enabled:
     stabilizer:
       estimator: 2 # 1: complementary, 2: kalman
       controller: 1 # 1: PID, 2: mellinger
+
+Finally make sure that the reference frame is set to 'cf231/odom' 
+
+.. code-block:: bash
+
+    reference_frame: cf231/odom
 
 If you are using a different name for your crazyflie, make sure to change the following in the example launch file (multiranger_simple_mapper_launch.py):
 
@@ -156,7 +162,7 @@ Go to crazyflie/config/crazyflie.yaml, change the URI of the crazyflie to the on
     enabled: true
     uri: radio://0/20/2M/E7E7E7E701
 
-And enable the following default topic logging:
+And enable the following default topic logging and the reference frames:
 
 .. code-block:: bash
 
@@ -176,6 +182,13 @@ Also, make sure that the standard controller is set to 1 (PID) for the flowdeck 
     stabilizer:
       estimator: 2 # 1: complementary, 2: kalman
       controller: 1 # 1: PID, 2: mellinger
+
+
+Finally make sure that the reference frame is set to 'cf231/odom' 
+
+.. code-block:: bash
+
+    reference_frame: cf231/odom
 
 
 Connecting with the Crazyflie
@@ -317,7 +330,7 @@ Preperation
 ~~~~~~~~~~~
 .. note::
 
-  This tutorial assume you have taken the above mapping tutorial first.
+  This tutorial assume you have done the above mapping tutorial first, along with the yaml file changes
 
 Find the all the files that were created by the RVIZ2 slam toolbox plugin, which should be in format \*.yaml, \*.posegraph, \*.data and \*.pgm, and copy them in the /crazyflie_examples/data/ folder.
 Either you can replace those that are there already ('map.\*'), or call them different and just change the name in the launch file, which will be explain now.

--- a/docs2/tutorials.rst
+++ b/docs2/tutorials.rst
@@ -403,7 +403,7 @@ Let's take a look at the launch file (multiranger_nav3_launch.py):
 
 The crazyflie_server, vel_mux and slam toolbox nodes are obviously the same as the mapping launch file example, with some key differences:
 
-* crazyflie_server: An extra parameter called 'world_tf_name' which changes the name of the 'world' transform to 'map'. This is to ensure compatibilty with the NAV2 bringup node later.
+* crazyflie_server: The reference frame is set to 'map'. This is to ensure compatibilty with the NAV2 bringup node later.
 * slam toolbox:  'map_frame' set to 'map, 'mode' set to localization with a 'map_file_name' and 'map_start_pose' (now remember marking the start position of the mapping tutorial?)
 
 The next two nodes are new, which are included IncludeLaunchDescription to include other launch files (since these are pretty big).


### PR DESCRIPTION
This PR contains:

* Clean up of crazyflie.yaml and update of version number (since this is a significant change)
* Update of crazyflie_server.py of the cflib backend to handle reference frame
* Update of rviz.py to use the reference frame assigned per crazyflie
* Update of crazyflie_server.py of the sim backend to input reference frames when the RVIZ visualizer is selected
* Update of ROS 2 tutorial (even though at one point we want to get to this but it's good to add it at least for now #640) 

fixes https://github.com/IMRCLab/crazyswarm2/issues/235