### PR TITLE
change the QoS service for build farm

### DIFF
--- a/.github/workflows/ci-ros2.yml
+++ b/.github/workflows/ci-ros2.yml
@@ -18,7 +18,6 @@ jobs:
           - humble
           - jazzy
           - rolling
-          - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
         include:

--- a/.github/workflows/ci-ros2.yml
+++ b/.github/workflows/ci-ros2.yml
@@ -12,10 +12,13 @@ jobs:
   build_docker: # On Linux, use docker
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: False
       matrix:
         ros_distribution:
           - humble
           - jazzy
+          - rolling
+          - rolling
 
         # Define the Docker image(s) associated with each ROS distribution.
         include:
@@ -27,6 +30,11 @@ jobs:
           # Jazzy Jalisco (May 2024 - May 2029)
           - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-ros-base-latest
             ros_distribution: jazzy
+            ros_version: 2
+
+          # Rolling Ridley  (June 2020 - Present)
+          - docker_image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+            ros_distribution: rolling
             ros_version: 2
 
     container:

--- a/crazyflie/CMakeLists.txt
+++ b/crazyflie/CMakeLists.txt
@@ -18,6 +18,13 @@ find_package(geometry_msgs REQUIRED)
 find_package(motion_capture_tracking_interfaces REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+if (DEFINED ENV{ROS_DISTRO})
+  set(ROS_DISTRO_VALUE "$ENV{ROS_DISTRO}")
+else()
+  message(WARNING "ROS_DISTRO environment variable not set. C++ macro will be empty or default.")
+  set(ROS_DISTRO_VALUE "unknown_distro") # Or an empty string, or "NO_ROS_DISTRO_SET"
+endif()
+
 # add dependencies
 add_subdirectory(deps/crazyflie_tools)
 # add_subdirectory(externalDependencies/libmotioncapture)
@@ -48,6 +55,11 @@ add_executable(crazyflie_server
 target_link_libraries(crazyflie_server
   crazyflie_cpp
 )
+
+if("${ROS_DISTRO_VALUE}" STREQUAL "humble")
+  target_compile_definitions(crazyflie_server PRIVATE ROS_DISTRO_HUMBLE)
+endif()
+
 ament_target_dependencies(crazyflie_server
   rclcpp
   tf2_ros

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -25,7 +25,6 @@
 #include "crazyflie_interfaces/msg/status.hpp"
 #include "crazyflie_interfaces/msg/log_data_generic.hpp"
 #include "crazyflie_interfaces/msg/connection_statistics_array.hpp"
-#include "rclcpp/qos.hpp"
 
 using std::placeholders::_1;
 using std::placeholders::_2;

--- a/crazyflie/src/crazyflie_server.cpp
+++ b/crazyflie/src/crazyflie_server.cpp
@@ -25,6 +25,7 @@
 #include "crazyflie_interfaces/msg/status.hpp"
 #include "crazyflie_interfaces/msg/log_data_generic.hpp"
 #include "crazyflie_interfaces/msg/connection_statistics_array.hpp"
+#include "rclcpp/qos.hpp"
 
 using std::placeholders::_1;
 using std::placeholders::_2;
@@ -40,6 +41,12 @@ using std_srvs::srv::Empty;
 
 using motion_capture_tracking_interfaces::msg::NamedPoseArray;
 using crazyflie_interfaces::msg::FullState;
+
+#ifdef ROS_DISTRO_HUMBLE
+inline auto get_service_qos() { return rmw_qos_profile_services_default; }
+#else
+inline auto get_service_qos() { return rclcpp::ServicesQoS(); }
+#endif
 
 // Note on logging: we use a single logger with string prefixes
 // A better way would be to use named child loggers, but these do not
@@ -156,14 +163,15 @@ public:
     // Services
     auto service_qos = rmw_qos_profile_services_default;
 
-    service_emergency_ = node->create_service<Empty>(name + "/emergency", std::bind(&CrazyflieROS::emergency, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_start_trajectory_ = node->create_service<StartTrajectory>(name + "/start_trajectory", std::bind(&CrazyflieROS::start_trajectory, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_takeoff_ = node->create_service<Takeoff>(name + "/takeoff", std::bind(&CrazyflieROS::takeoff, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_land_ = node->create_service<Land>(name + "/land", std::bind(&CrazyflieROS::land, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_go_to_ = node->create_service<GoTo>(name + "/go_to", std::bind(&CrazyflieROS::go_to, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_upload_trajectory_ = node->create_service<UploadTrajectory>(name + "/upload_trajectory", std::bind(&CrazyflieROS::upload_trajectory, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_notify_setpoints_stop_ = node->create_service<NotifySetpointsStop>(name + "/notify_setpoints_stop", std::bind(&CrazyflieROS::notify_setpoints_stop, this, _1, _2), service_qos, callback_group_cf_srv);
-    service_arm_ = node->create_service<Arm>(name + "/arm", std::bind(&CrazyflieROS::arm, this, _1, _2), service_qos, callback_group_cf_srv);
+
+    service_emergency_ = node->create_service<Empty>(name + "/emergency", std::bind(&CrazyflieROS::emergency, this, _1, _2),  get_service_qos(), callback_group_cf_srv);
+    service_start_trajectory_ = node->create_service<StartTrajectory>(name + "/start_trajectory", std::bind(&CrazyflieROS::start_trajectory, this, _1, _2), get_service_qos(), callback_group_cf_srv);
+    service_takeoff_ = node->create_service<Takeoff>(name + "/takeoff", std::bind(&CrazyflieROS::takeoff, this, _1, _2), get_service_qos(), callback_group_cf_srv);
+    service_land_ = node->create_service<Land>(name + "/land", std::bind(&CrazyflieROS::land, this, _1, _2), get_service_qos(), callback_group_cf_srv);
+    service_go_to_ = node->create_service<GoTo>(name + "/go_to", std::bind(&CrazyflieROS::go_to, this, _1, _2), get_service_qos(), callback_group_cf_srv);
+    service_upload_trajectory_ = node->create_service<UploadTrajectory>(name + "/upload_trajectory", std::bind(&CrazyflieROS::upload_trajectory, this, _1, _2), get_service_qos(), callback_group_cf_srv);
+    service_notify_setpoints_stop_ = node->create_service<NotifySetpointsStop>(name + "/notify_setpoints_stop", std::bind(&CrazyflieROS::notify_setpoints_stop, this, _1, _2), get_service_qos(), callback_group_cf_srv);
+    service_arm_ = node->create_service<Arm>(name + "/arm", std::bind(&CrazyflieROS::arm, this, _1, _2), get_service_qos(), callback_group_cf_srv);
 
     // Topics
 
@@ -1142,17 +1150,15 @@ public:
     subscription_cmd_full_state_ = this->create_subscription<crazyflie_interfaces::msg::FullState>("all/cmd_full_state", rclcpp::SystemDefaultsQoS(), std::bind(&CrazyflieServer::cmd_full_state_changed, this, _1), sub_opt_all_cmd);
 
     // services for "all"
-    auto service_qos = rmw_qos_profile_services_default;
-
-    service_start_trajectory_ = this->create_service<StartTrajectory>("all/start_trajectory", std::bind(&CrazyflieServer::start_trajectory, this, _1, _2), service_qos, callback_group_all_srv_);
-    service_takeoff_ = this->create_service<Takeoff>("all/takeoff", std::bind(&CrazyflieServer::takeoff, this, _1, _2), service_qos, callback_group_all_srv_);
-    service_land_ = this->create_service<Land>("all/land", std::bind(&CrazyflieServer::land, this, _1, _2), service_qos, callback_group_all_srv_);
-    service_go_to_ = this->create_service<GoTo>("all/go_to", std::bind(&CrazyflieServer::go_to, this, _1, _2), service_qos, callback_group_all_srv_);
-    service_notify_setpoints_stop_ = this->create_service<NotifySetpointsStop>("all/notify_setpoints_stop", std::bind(&CrazyflieServer::notify_setpoints_stop, this, _1, _2), service_qos, callback_group_all_srv_);
-    service_arm_ = this->create_service<Arm>("all/arm", std::bind(&CrazyflieServer::arm, this, _1, _2), service_qos, callback_group_all_srv_);
+    service_start_trajectory_ = this->create_service<StartTrajectory>("all/start_trajectory", std::bind(&CrazyflieServer::start_trajectory, this, _1, _2), get_service_qos(), callback_group_all_srv_);
+    service_takeoff_ = this->create_service<Takeoff>("all/takeoff", std::bind(&CrazyflieServer::takeoff, this, _1, _2), get_service_qos(), callback_group_all_srv_);
+    service_land_ = this->create_service<Land>("all/land", std::bind(&CrazyflieServer::land, this, _1, _2), get_service_qos(), callback_group_all_srv_);
+    service_go_to_ = this->create_service<GoTo>("all/go_to", std::bind(&CrazyflieServer::go_to, this, _1, _2), get_service_qos(), callback_group_all_srv_);
+    service_notify_setpoints_stop_ = this->create_service<NotifySetpointsStop>("all/notify_setpoints_stop", std::bind(&CrazyflieServer::notify_setpoints_stop, this, _1, _2), get_service_qos(), callback_group_all_srv_);
+    service_arm_ = this->create_service<Arm>("all/arm", std::bind(&CrazyflieServer::arm, this, _1, _2), get_service_qos(), callback_group_all_srv_);
 
     // This is the last service to announce and can be used to check if the server is fully available
-    service_emergency_ = this->create_service<Empty>("all/emergency", std::bind(&CrazyflieServer::emergency, this, _1, _2), service_qos, callback_group_all_srv_);
+    service_emergency_ = this->create_service<Empty>("all/emergency", std::bind(&CrazyflieServer::emergency, this, _1, _2), get_service_qos(), callback_group_all_srv_);
   }
 
 


### PR DESCRIPTION
Might fix these errors in the build farm?

```
23:53:50 /tmp/ws/src/crazyflie/crazyflie/src/crazyflie_server.cpp:159:53: error: no matching function for call to ‘rclcpp::Node::create_service<std_srvs::srv::Empty>(std::__cxx11::basic_string<char>, std::_Bind_helper<false, void (CrazyflieROS::*)(std::shared_ptr<std_srvs::srv::Empty_Request_<std::allocator<void> > >, std::shared_ptr<std_srvs::srv::Empty_Response_<std::allocator<void> > >), CrazyflieROS*, const std::_Placeholder<1>&, const std::_Placeholder<2>&>::type, rmw_qos_profile_s&, rclcpp::CallbackGroup::SharedPtr&)’
23:53:50   159 |     service_emergency_ = node->create_service<Empty>(name + "/emergency", std::bind(&CrazyflieROS::emergency, this, _1, _2), service_qos, callback_group_cf_srv);
```