### PR TITLE
add more dependencies to fix the binary build

### DIFF
--- a/crazyflie_interfaces/package.xml
+++ b/crazyflie_interfaces/package.xml
@@ -15,6 +15,7 @@
 
   <depend>geometry_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
@@ -23,6 +24,9 @@
 
   <!-- For build failures on humble, see https://answers.ros.org/question/416825/ -->
   <test_depend>ament_cmake_cppcheck</test_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
I've added these test depends as those come in standard when generating a standard message

```
  <test_depend>ament_lint_auto</test_depend>
  <test_depend>ament_lint_common</test_depend>
```

I've also added a dependencies on std_msgs as we do use some standards in some of the messages
```
  <depend>std_msgs</depend>
```
Now fingers crossed!