### PR TITLE
wrong package.xml

### DIFF
--- a/crazyflie/package.xml
+++ b/crazyflie/package.xml
@@ -17,7 +17,7 @@
   <depend>sensor_msgs</depend>
   <depend>crazyflie_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <depend>nav2_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>motion_capture_tracking_interfaces</depend>
   <depend>eigen</depend>
   <depend>boost</depend>


### PR DESCRIPTION
I've put nav2_msgs in the package.xml but this needs to be nav_msgs.

Adding rosdep to CI would have caught this more locally.