### PR TITLE
instructions to install release 2025.02 crazyflie firmware

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 Crazyswarm2 runs on **Ubuntu Linux** in one of the following configurations:
 
-====== ======== ======
+====== ======== ====== 
 Ubuntu Python   ROS 2
 ------ -------- ------
 22.04  3.10     Humble
@@ -85,11 +85,11 @@ First Installation
 
 7. Set up software-in-the-loop simulation (optional)
 
-    This currently requires cloning the Crazyflie firmware and building the Python bindings manually. In a separate folder (not part of your ROS 2 workspace!), 
+    This currently requires cloning the Crazyflie firmware of the latest tested release (2025.02) and building the Python bindings manually. In a separate folder (not part of your ROS 2 workspace!), 
 
     .. code-block:: bash
 
-        git clone --recursive https://github.com/bitcraze/crazyflie-firmware.git
+        git clone --branch 2025.02 --single-branch --recursive https://github.com/bitcraze/crazyflie-firmware.git
 
     First follow `the instructions to build the python bindings <https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/building-and-flashing/build/#build-python-bindings>`_ from the bitcraze website. Afterwards, make sure that the bindings can be found in the python path:
 


### PR DESCRIPTION
Temporary fix for this https://github.com/IMRCLab/crazyswarm2/issues/741. We should aim to get it working on the latest release only and not master anyway