### PR TITLE
Fix formatting in installation instructions

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -78,17 +78,18 @@ First Installation
                 cd ros2_ws/src
                 git clone https://github.com/IMRCLab/crazyswarm2 --recursive
 
-             Now build the ROS 2 workspace
-             .. code-block:: bash
-         
+            Now build the ROS 2 workspace
+
+            .. code-block:: bash
+
                 cd ../
                 source /opt/ros/DISTRO/setup.bash
                 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
          
-             .. note::
+            .. note::
                 symlink-install allows you to edit Python and config files without running `colcon build` every time.
          
-             .. note::
+            .. note::
                 If you install it for the first time, you will see a lot of warnings at first. 
                 As long as the build of the package finish, you can ignore this for now. 
        


### PR DESCRIPTION
The installation doc now looks like this:

<img width="915" height="662" alt="image" src="https://github.com/user-attachments/assets/074bc5f1-27f0-4dee-9784-bf83494542f9" />

Hopefully this PR fixes those formatting issues. 

I need to find a good way to check the website locally....