### PR TITLE
adding cmd_velocity_world for cflib backend

### DIFF
--- a/crazyflie/scripts/crazyflie_server.py
+++ b/crazyflie/scripts/crazyflie_server.py
@@ -1162,7 +1162,6 @@ class CrazyflieServer(Node):
         Topic update callback to control the world velocity command
             of the crazyflie
         """
-        self.get_logger().info(f"[{self.cf_dict[uri]}] Velocity World Setpoint: vx:{msg.vel.x}, vy:{msg.vel.y}, vz:{msg.vel.z}, yaw_rate:{msg.yaw_rate}")
         vel = msg.vel
         vx = vel.x
         vy = vel.y


### PR DESCRIPTION
I wanted to use the drones as a single integrator model, but neither the cpp backend nor the cflib backend incorporated velocity_world setpoints. The interface msg/VelocityWorld.msg already existed, but wasn't being used in both the cpp and cflib backend. For now, I added this for the cflib backend only. 