### PR TITLE
Simplifying installation instructions by changing dependencies

### DIFF
--- a/crazyflie/launch/launch.py
+++ b/crazyflie/launch/launch.py
@@ -127,7 +127,7 @@ def generate_launch_description():
         DeclareLaunchArgument('backend', default_value='cpp'),
         DeclareLaunchArgument('debug', default_value='False'),
         DeclareLaunchArgument('rviz', default_value='False'),
-        DeclareLaunchArgument('gui', default_value='True'),
+        DeclareLaunchArgument('gui', default_value='False'),
         DeclareLaunchArgument('teleop', default_value='True'),
         DeclareLaunchArgument('mocap', default_value='True'),
         DeclareLaunchArgument('teleop_yaml_file', default_value=''),

--- a/crazyflie/package.xml
+++ b/crazyflie/package.xml
@@ -23,9 +23,7 @@
   <depend>boost</depend>
   <depend>libusb-1.0-dev</depend>
   <depend>ros_environment</depend>
-
-
-  <exec_depend>tf_transformations</exec_depend>
+  <depend>python3-transforms3d</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/crazyflie/scripts/simple_mapper_multiranger.py
+++ b/crazyflie/scripts/simple_mapper_multiranger.py
@@ -17,8 +17,7 @@ from sensor_msgs.msg import LaserScan
 from nav_msgs.msg import OccupancyGrid
 from geometry_msgs.msg import TransformStamped
 from tf2_ros import StaticTransformBroadcaster
-
-import tf_transformations
+from transforms3d.euler import quat2euler
 import math
 import numpy as np
 from bresenham import bresenham
@@ -68,7 +67,8 @@ class SimpleMapperMultiranger(Node):
         self.position[1] = msg.pose.pose.position.y
         self.position[2] = msg.pose.pose.position.z
         q = msg.pose.pose.orientation
-        euler = tf_transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])
+        # transforms3d expects (w, x, y, z)
+        euler = quat2euler([q.w, q.x, q.y, q.z], axes='sxyz')
         self.angles[0] = euler[0]
         self.angles[1] = euler[1]
         self.angles[2] = euler[2]

--- a/crazyflie_examples/launch/launch.py
+++ b/crazyflie_examples/launch/launch.py
@@ -30,6 +30,7 @@ def generate_launch_description():
             '/launch.py']),
         launch_arguments={
             'backend': backend,
+            'rviz': 'True'
             }.items()
     )
 

--- a/crazyflie_sim/crazyflie_sim/backend/np.py
+++ b/crazyflie_sim/crazyflie_sim/backend/np.py
@@ -9,79 +9,63 @@ from ..sim_data_types import Action, State
 
 
 # Quaternion utility functions (replacing rowan dependency)
-def quat_rotate(q, v):
-    """Rotate vector v by quaternion q. Quaternion format: [x, y, z, w]"""
-    # Extract quaternion components
-    qx, qy, qz, qw = q[0], q[1], q[2], q[3]
-    
-    # Extract vector components
-    vx, vy, vz = v[0], v[1], v[2]
-    
-    # Perform rotation: v' = q * v * q^(-1)
-    # Using formula: v' = v + 2 * cross(q_vec, cross(q_vec, v) + q_w * v)
-    qvec = np.array([qx, qy, qz])
-    cross1 = np.cross(qvec, v)
-    cross2 = cross1 + qw * v
-    cross3 = np.cross(qvec, cross2)
-    return v + 2.0 * cross3
+# NOTE: Quaternion format throughout is [qw, qx, qy, qz] (scalar-first),
+# matching sim_data_types.State documentation.
 
-
-def quat_normalize(q):
-    """Normalize a quaternion. Quaternion format: [x, y, z, w]"""
+def quat_normalize(q: np.ndarray) -> np.ndarray:
+    """Normalize a quaternion [qw, qx, qy, qz]."""
     norm = np.linalg.norm(q)
-    if norm < 1e-10:
-        return np.array([0.0, 0.0, 0.0, 1.0])
+    if norm < 1e-12:
+        return np.array([1.0, 0.0, 0.0, 0.0])
     return q / norm
 
 
-def quat_integrate(q, omega, dt):
-    """Integrate quaternion with angular velocity omega over timestep dt.
-    q: quaternion [x, y, z, w]
-    omega: angular velocity in body frame [wx, wy, wz]
-    dt: timestep
-    """
-    # Quaternion derivative: dq/dt = 0.5 * q * omega_quat
-    # where omega_quat = [omega_x, omega_y, omega_z, 0]
-    
-    # For small dt, we can use: q(t+dt) ≈ q(t) + 0.5 * dt * q(t) * omega_quat
-    # More accurately, we use exponential map for integration
-    
-    theta = np.linalg.norm(omega) * dt
-    
-    if theta < 1e-10:
-        # No rotation
-        return q
-    
-    # Axis of rotation (normalized)
-    axis = omega / np.linalg.norm(omega)
-    
-    # Quaternion representing the rotation: [sin(theta/2)*axis, cos(theta/2)]
-    half_theta = theta / 2.0
-    sin_half = np.sin(half_theta)
-    cos_half = np.cos(half_theta)
-    
-    dq = np.array([
-        sin_half * axis[0],
-        sin_half * axis[1],
-        sin_half * axis[2],
-        cos_half
-    ])
-    
-    # Quaternion multiplication: q_new = dq * q
-    return quat_multiply(dq, q)
+def quat_conjugate(q: np.ndarray) -> np.ndarray:
+    """Conjugate of quaternion [qw, qx, qy, qz]."""
+    return np.array([q[0], -q[1], -q[2], -q[3]])
 
 
-def quat_multiply(q1, q2):
-    """Multiply two quaternions. Quaternion format: [x, y, z, w]"""
-    x1, y1, z1, w1 = q1[0], q1[1], q1[2], q1[3]
-    x2, y2, z2, w2 = q2[0], q2[1], q2[2], q2[3]
-    
+def quat_multiply(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """Hamilton product q1 ⊗ q2 for [qw, qx, qy, qz] ordering."""
+    w1, x1, y1, z1 = q1[0], q1[1], q1[2], q1[3]
+    w2, x2, y2, z2 = q2[0], q2[1], q2[2], q2[3]
     return np.array([
+        w1*w2 - x1*x2 - y1*y2 - z1*z2,
         w1*x2 + x1*w2 + y1*z2 - z1*y2,
         w1*y2 - x1*z2 + y1*w2 + z1*x2,
         w1*z2 + x1*y2 - y1*x2 + z1*w2,
-        w1*w2 - x1*x2 - y1*y2 - z1*z2
     ])
+
+
+def quat_rotate(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Rotate vector v (3,) by quaternion q=[qw,qx,qy,qz] using v' = q ⊗ [0,v] ⊗ q*.
+    Assumes q maps body -> world if used as in this simulator.
+    """
+    qn = quat_normalize(q)
+    vq = np.array([0.0, v[0], v[1], v[2]])
+    return quat_multiply(quat_multiply(qn, vq), quat_conjugate(qn))[1:4]
+
+
+def quat_from_axis_angle(axis: np.ndarray, angle: float) -> np.ndarray:
+    """Quaternion [qw,qx,qy,qz] from axis (3,) and angle (rad)."""
+    axis_n = axis / (np.linalg.norm(axis) + 1e-16)
+    half = angle * 0.5
+    s = np.sin(half)
+    c = np.cos(half)
+    return np.array([c, axis_n[0]*s, axis_n[1]*s, axis_n[2]*s])
+
+
+def quat_integrate(q: np.ndarray, omega_world: np.ndarray, dt: float) -> np.ndarray:
+    """Integrate quaternion with world-frame angular velocity over dt.
+    Uses exponential map: q_next = exp(0.5*dt*Omega) ⊗ q, where exp maps so(3)->SU(2).
+    """
+    theta = np.linalg.norm(omega_world) * dt
+    if theta < 1e-12:
+        return q
+    dq = quat_from_axis_angle(omega_world, theta)
+    # dq corresponds to rotation by angle theta about axis omega_world/||omega|| in world frame
+    # For world-frame omega, apply left-multiplication
+    return quat_multiply(dq, q)
 
 
 class Backend:
@@ -125,7 +109,7 @@ class Backend:
 
 
 class Quadrotor:
-    """Basic rigid body quadrotor model (no drag) using numpy and rowan."""
+    """Basic rigid body quadrotor model (no drag) using numpy."""
 
     def __init__(self, state):
         # parameters (Crazyflie 2.0 quadrotor)

--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -37,18 +37,21 @@ First Installation
 
         .. group-tab:: Source Installation
 
+            Use rosdep to install all the dependencies
+
             .. code-block:: bash
 
-                sudo apt install libboost-program-options-dev libusb-1.0-0-dev
-                pip3 install rowan nicegui
+                rosdep install --from-paths src -y --ignore-src
+            
+            If you'd like to use the webgui for status monitoring, install nicegui
 
-   Then install the motion capture ROS 2 package (replace <DISTRO> with your version of ROS, namely humble or jazzy):
+            .. code-block:: bash
 
-    .. code-block:: bash
+                pip3 install nicegui
 
-        sudo apt-get install ros-<DISTRO>-motion-capture-tracking 
 
-    If you are planning to use the CFlib backend, do:
+
+    For both the binary installation as the source installation: you are planning to use the CFlib backend, do:
 
     .. code-block:: bash
         

--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -55,8 +55,7 @@ First Installation
 
     .. code-block:: bash
         
-        pip3 install cflib transforms3d
-        sudo apt-get install ros-<DISTRO>-tf-transformations
+        pip3 install cflib 
 
 3. Set up your ROS 2 workspace
 


### PR DESCRIPTION
There are a lot of ifs and buts when installing crazyswarm2. This draft PR is a suggestion to simplication.

What I've done is:

* Nice gui is optional now (as that is not installable as a pip package)
* Changed all tf-transformations to transform3d (that is a system package)
* Inputted all rowan functions to np.py backend (tested this with figure8 and it should work)
* Use rosdep to install dependencies

I also notice that rviz for the single line hello world didn't work anymore, which is because it's now defaulted to False, so here it is back on. 

This should fix the following issues:

* fix #746 (since this is not used in the build system anyway)
