### PR TITLE
Specify nicegui version in installation instructions

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -40,7 +40,7 @@ First Installation
             .. code-block:: bash
 
                 sudo apt install libboost-program-options-dev libusb-1.0-0-dev
-                pip3 install rowan nicegui
+                pip3 install rowan nicegui==1.4.2
 
    Then install the motion capture ROS 2 package (replace <DISTRO> with your version of ROS, namely humble or jazzy):
 


### PR DESCRIPTION
fixes #782

The idea is to replace nicegui with an rviz2 plugin at one point as that would be better, but for let's fix the version