### PR TITLE
nicegui versioning for binary installation doc

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -33,7 +33,7 @@ First Installation
 
             .. code-block:: bash
 
-                pip3 install rowan nicegui
+                pip3 install rowan nicegui==1.4.2
 
         .. group-tab:: Source Installation
 


### PR DESCRIPTION
I saw that the nicegui version was only specified for the source installation, so here for the binary installation too