### PR TITLE
Update installation instructions with pip warning

### DIFF
--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -103,7 +103,7 @@ First Installation
                Please pip install then the following and try again:
                
                .. code-block:: bash
-                  pip3 install catkin_pkg lark-parser empy==3.3. colcon-common-extensions
+                  pip3 install catkin_pkg lark-parser empy==3.3.4 colcon-common-extensions
                
        
 

--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -96,7 +96,15 @@ First Installation
          
             .. note::
                 If you install it for the first time, you will see a lot of warnings at first. 
-                As long as the build of the package finish, you can ignore this for now. 
+                As long as the build of the package finish, you can ignore this for now.
+
+            .. warning::
+               If you get build errors from missing pip, your machine are probably missing some additional packages that were missed in the initial ROS installation (see this `issue <https://github.com/IMRCLab/crazyswarm2/issues/863/>`_.)
+               Please pip install then the following and try again:
+               
+               .. code-block:: bash
+                  pip3 install catkin_pkg lark-parser empy==3.3. colcon-common-extensions
+               
        
 
 4. Set up Crazyradio

--- a/docs2/installation.rst
+++ b/docs2/installation.rst
@@ -103,6 +103,7 @@ First Installation
                Please pip install then the following and try again:
                
                .. code-block:: bash
+
                   pip3 install catkin_pkg lark-parser empy==3.3.4 colcon-common-extensions
                
        


### PR DESCRIPTION
It seems that on some machine ROS2 does not install all the required pip packages yet. Unfortunately this is not reproducible on CI but on some VMs this occurs (see this issue https://github.com/IMRCLab/crazyswarm2/issues/863).

See this old issue of this that we closed before but I haven't seen this happen on my WSL2 ubuntu machines anymore: https://github.com/IMRCLab/crazyswarm2/issues/553

