### PR TITLE
Update CI badge links for crazyswarm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 * Local CI: [![ROS 2](https://github.com/IMRCLab/crazyswarm2/actions/workflows/ci-ros2.yml/badge.svg)](https://github.com/IMRCLab/crazyswarm2/actions/workflows/ci-ros2.yml)
-* Rolling Dev CI : [![Build Status](https://build.ros2.org/job/Rdev__crazyflie__ubuntu_resolute_amd64/badge/icon)](https://build.ros2.org/job/Rdev__crazyflie__ubuntu_resolute_amd64/) (crazyflie only)
-* Lyrical Dev CI : [![Build Status](https://build.ros2.org/job/Ldev__crazyflie__ubuntu_resolute_amd64/badge/icon)](https://build.ros2.org/job/Ldev__crazyflie__ubuntu_resolute_amd64/) (crazyflie only)
+* Rolling Dev CI : [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rdev__crazyswarm2__ubuntu_resolute_amd64)](https://build.ros2.org/job/Rdev__crazyswarm2__ubuntu_resolute_amd64/)
+* Lyrical Dev CI : [![Build Status](https://build.ros2.org/buildStatus/icon?job=Ldev__crazyswarm2__ubuntu_resolute_amd64)](https://build.ros2.org/job/Ldev__crazyswarm2__ubuntu_resolute_amd64/)
 * Jazzy Dev CI: [![Build Status](https://build.ros2.org/job/Jdev__crazyswarm2__ubuntu_noble_amd64/badge/icon)](https://build.ros2.org/job/Jdev__crazyswarm2__ubuntu_noble_amd64/)
 * Humble Dev CI: [![Build Status](https://build.ros2.org/job/Hdev__crazyswarm2__ubuntu_jammy_amd64/badge/icon)](https://build.ros2.org/job/Hdev__crazyswarm2__ubuntu_jammy_amd64/)
 


### PR DESCRIPTION
The ci links are broken to the crazyswarm2 builds on the ros2 build farm so just a quick update!