### PR TITLE
fix: add /all/notify_setpoints_stop service in crazyflie_server.py

### DIFF
--- a/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
+++ b/crazyflie_server_py/crazyflie_server_py/crazyflie_server.py
@@ -417,6 +417,9 @@ class CrazyflieServer(Node):
         self.create_service(
             StartTrajectory, 'all/start_trajectory', self._start_trajectory_callback
         )
+        self.create_service(
+            NotifySetpointsStop, 'all/notify_setpoints_stop', self._notify_setpoints_stop_callback
+        )
 
         # This is the last service to announce and can be used to check if
         # the server is fully available.


### PR DESCRIPTION
### Summary

Registers `all/notify_setpoints_stop` service.
It is using the existing _notify_setpoints_stop_callback, which already handles uri='all' via its default parameter.

### Motivation

Closes #871. The `uri='all'` default on the function signature indicates the group case was intended, but without a registered service, that code path is not reachable.

### Test
Verified on hardware with two Crazyflie 2.1 drones, driven by our own mode-transition node (not part of this repo) exercising the new service:
1. Call` /all/takeoff`.
2. Send VelocityWorld topic based setpoints to the Crazyflies (velocity control).
3. Stop streaming setpoints, wait ~0.3s, then call `/all/notify_setpoints_stop`.
4. Call `/all/land`.

### Result
Before this change, step 4 had no effect. The high-level commander stayed locked out and the drones did not descend. . With `/all/notify_setpoints_stop` registered, the high-level commander regains control in step 3, and `/all/land` in step 4 executes a descent trajectory identical to the case where no velocity setpoints (step 2) had ever been sent.