### PR TITLE
add rclpy to package.xml

### DIFF
--- a/crazyflie/package.xml
+++ b/crazyflie/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rclpy</depend>
   <depend>std_srvs</depend>
   <depend>sensor_msgs</depend>
   <depend>crazyflie_interfaces</depend>


### PR DESCRIPTION
Hopefully will fix the failing buildfarm issues like this one: https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__crazyflie__ubuntu_noble_amd64__binary/62/